### PR TITLE
[SPARKLER] use case statements to handle option types for the outLink filter

### DIFF
--- a/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/Crawler.scala
+++ b/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/Crawler.scala
@@ -149,7 +149,10 @@ object OutLinkFilterFunc extends ((SparklerJob, RDD[CrawlData]) => RDD[Resource]
 
       .filter({case (url, parent) =>
         val outLinkFilter:scala.Option[URLFilter] = PluginService.getExtension(classOf[URLFilter], job)
-        val result = outLinkFilter.get.filter(url, parent.url)
+        val result = outLinkFilter match {
+          case Some(urLFilter) => urLFilter.filter(url, parent.url)
+          case None => true
+        }
         LOG.debug(s"$result :: filter(${parent.url} --> $url)")
         result
       })


### PR DESCRIPTION
The case statement on the outLinkFilter will either
use the filter (if it is there) or just accept the url if no filter has been found.