### PR TITLE
[SPARKLER 6] Kafka Connector Data Sink

### DIFF
--- a/conf/sparkler-default.yaml
+++ b/conf/sparkler-default.yaml
@@ -36,8 +36,8 @@ spark.master: local
 # Type: String. Default is "localhost:9092" for local mode.
 kafka.listeners: localhost:9092
 # Kafka topic to send dumps to
-# Type: String. Default is "sparkler".
-kafka.topic: sparkler
+# Type: String. Default is "sparkler/<jobid>".
+kafka.topic: sparkler_%s
 
 ##################### Generate Properties ###############################
 

--- a/conf/sparkler-default.yaml
+++ b/conf/sparkler-default.yaml
@@ -30,6 +30,14 @@ crawldb.uri: http://localhost:8983/solr/crawldb
 spark.master: local
 
 
+##################### Apache Kafka Properties ###########################
+
+# Kafka Listeners
+# Type: String. Default is "localhost:9092" for local mode.
+kafka.listeners: localhost:9092
+# Kafka topic to send dumps to
+# Type: String. Default is "sparkler".
+kafka.topic: sparkler
 
 ##################### Generate Properties ###############################
 

--- a/sparkler-api/src/main/java/edu/usc/irds/sparkler/Constants.java
+++ b/sparkler-api/src/main/java/edu/usc/irds/sparkler/Constants.java
@@ -44,6 +44,13 @@ public interface Constants {
         @ConfigKey
         String SPARK_MASTER = "spark.master";
 
+        // Apache Kafka Properties
+        @ConfigKey
+        String KAFKA_LISTENERS = "kafka.listeners";
+
+        @ConfigKey
+        String KAFKA_TOPIC = "kafka.topic";
+
         // HTTP Properties
 
         // Database Properties

--- a/sparkler-app/pom.xml
+++ b/sparkler-app/pom.xml
@@ -62,11 +62,11 @@
             <version>${nutch.version}</version>
         </dependency>
 
-        <!-- <dependency>
+        <dependency>
            <groupId>org.apache.kafka</groupId>
            <artifactId>kafka-clients</artifactId>
            <version>${kafka.version}</version>
-         </dependency>-->
+         </dependency>
 
         <!--<dependency>
           <groupId>org.apache.hbase</groupId>

--- a/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/Crawler.scala
+++ b/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/Crawler.scala
@@ -121,7 +121,7 @@ class Crawler extends CliTool {
         .flatMap({ case (grp, rs) => new FairFetcher(rs.iterator, localFetchDelay, FetchFunction, ParseFunction) })
         .persist()
 
-      storeContentKafka(kafkaListeners, kafkaTopic, fetchedRdd)
+      storeContentKafka(kafkaListeners, kafkaTopic.format(jobId), fetchedRdd)
 
       //Step: Update status of fetched resources
       val statusUpdateRdd: RDD[SolrInputDocument] = fetchedRdd.map(d => StatusUpdateSolrTransformer(d))

--- a/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/SparklerProducer.scala
+++ b/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/SparklerProducer.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.usc.irds.sparkler.pipeline
+
+import java.util.Properties
+
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+
+/**
+ * The primary purpose of the Sparkler Producer is to write dump files to
+ * the kafka messaging system. Users must have configured kafka with atleast one
+ * listener. Note that the SparklerProducer should be instantiated within a map
+ * task. It is purposely made not serializable as the KafkaProducer is not serializable.
+ * This object should not be instantiated outside of a RDD transformation function and then
+ * used inside it.
+ * @param listeners a comma separated list of listeners. Example : host1:9092, host2:9093
+ * @param topic the kafka topic to use for sparkler
+ */
+class SparklerProducer(listeners: String, topic: String) {
+
+  val props : Properties = new Properties()
+  props.put("bootstrap.servers", listeners)
+  props.put("acks", "all")
+  props.put("retries", "0")
+  props.put("batch.size", "16384")
+  props.put("linger.ms", "1")
+  props.put("buffer.memory", "33554432")
+  props.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer")
+  props.put("value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer")
+  val producer = new KafkaProducer[String, Array[Byte]](props)
+
+  /**
+   * Add additional properties to the KafkaProducer as
+   * Key Value pairs of Strings.
+   * @param key   the property name
+   * @param value the property value
+   */
+  def putProperty(key: String, value: String): Unit ={
+    props.put(key, value)
+  }
+
+  /**
+   * Sends a dump string to the producer.
+   * If the topic doesn't exist, then kafka auto-creates the topic.
+   * @param dump the dump message to send to the producer.
+   */
+  def send(dump : Array[Byte]): Unit = {
+    producer.send(new ProducerRecord[String, Array[Byte]](topic, dump))
+  }
+
+}


### PR DESCRIPTION
Addresses issue #6 

Details about the PR:
- Default kafka.listeners and kafka.topic was added to sparkler-default.yaml
- Kafka dependency was uncommented in spark-app/pom.xml
- In Crawler.scala added storeContentKafka()
- Added SparklerProducer.scala

To have the PR working : Need to setup kafka and have it listen on default port of 9092 on localhost.
You can follow the instructions here : starting from step 2 if you already have java installed.
http://www.tutorialspoint.com/apache_kafka/apache_kafka_installation_steps.htm

To verify the dumps, open up a listener on topic "sparkler" in terminal.

When running the crawl the kafka producer outputs its properties and it is quite a large [string](https://gist.github.com/rahulpalamuttam/aa35fe7a8070e4db3cce37301e694f9b).
Do we want to turn it off?
@thammegowda @karanjeets 

