### PR TITLE
[SPARKLER 33] Disable kafka by default with kafka.enabled parameter

### DIFF
--- a/conf/sparkler-default.yaml
+++ b/conf/sparkler-default.yaml
@@ -31,7 +31,9 @@ spark.master: local
 
 
 ##################### Apache Kafka Properties ###########################
-
+# Enable Kafka Dump
+# Type: Boolean. Default is "false"
+kafka.enable: false
 # Kafka Listeners
 # Type: String. Default is "localhost:9092" for local mode.
 kafka.listeners: localhost:9092

--- a/sparkler-api/src/main/java/edu/usc/irds/sparkler/Constants.java
+++ b/sparkler-api/src/main/java/edu/usc/irds/sparkler/Constants.java
@@ -46,6 +46,9 @@ public interface Constants {
 
         // Apache Kafka Properties
         @ConfigKey
+        String KAFKA_ENABLE = "kafka.enable";
+
+        @ConfigKey
         String KAFKA_LISTENERS = "kafka.listeners";
 
         @ConfigKey


### PR DESCRIPTION
The following PR addresses issue #33 

1. `kafka.enabled` parameter has been added with default value as false.
     Note that the yaml class reads this in as a boolean.

2. The config parameter is checked before sending content to kafka

@thammegowda @karanjeets 