### PR TITLE
Deduplication of Solr Documents

### DIFF
--- a/conf/solr-schema-map.yaml
+++ b/conf/solr-schema-map.yaml
@@ -15,8 +15,8 @@
 
 ################## Solr Schema Map Properties #######################
 
-overrides:
-  id: id
+#overrides:
+#  id: id
 
 typeSuffix:
   java.lang.String: _t

--- a/conf/solr/crawldb/conf/managed-schema
+++ b/conf/solr/crawldb/conf/managed-schema
@@ -153,6 +153,7 @@
   <!-- Admin -->
   <field name="indexed_at" type="date" indexed="true" stored="true" multiValued="false" default="NOW" />
   <field name="last_updated_at" type="date" indexed="true" stored="true" multiValued="false" default="NOW" />
+  <field name="dedupe_id" type="string" stored="true" indexed="true" multiValued="false" />
 
 
   <!-- Future Use -->         

--- a/sparkler-api/src/main/java/edu/usc/irds/sparkler/Constants.java
+++ b/sparkler-api/src/main/java/edu/usc/irds/sparkler/Constants.java
@@ -157,6 +157,7 @@ public interface Constants {
         String SIGNATURE = "signature";
         String OUTLINKS = "outlinks";
         String RELATIVE_PATH = "relative_path";
+        String DEDUPE_ID = "dedupe_id";
         String MD_SUFFIX = "_md";
     }
 

--- a/sparkler-api/src/main/java/edu/usc/irds/sparkler/model/Resource.java
+++ b/sparkler-api/src/main/java/edu/usc/irds/sparkler/model/Resource.java
@@ -29,6 +29,8 @@ public class Resource implements Serializable {
     @Field("indexed_at") private Date indexedAt;
     @Field private String hostname;
     @Field private String parent;
+    @Field("dedupe_id") private String dedupeId;
+
 
     public Resource() {
     }
@@ -40,6 +42,7 @@ public class Resource implements Serializable {
         this.group = group;
         this.hostname = group;
         this.crawlId = job.getId();
+        this.dedupeId = StringUtil.sha256hash(url + "-" + job.getId());
     }
 
     public Resource(String url, String group, JobContext sparklerJob, Date fetchTimestamp) {
@@ -123,4 +126,12 @@ public class Resource implements Serializable {
     public Date getFetchTimestamp() { return fetchTimestamp; }
 
     public void setFetchTimestamp(Date fetchTimestamp) { this.fetchTimestamp = fetchTimestamp; }
+
+    public String getCrawlId() { return crawlId; }
+
+    public void setCrawlId(String crawlId) { this.crawlId = crawlId; }
+
+    public String getDedupeId() { return dedupeId; }
+
+    public void setDedupeId(String dedupeId) { this.dedupeId = dedupeId; }
 }

--- a/sparkler-api/src/main/java/edu/usc/irds/sparkler/solr/schema/StringEvaluator.java
+++ b/sparkler-api/src/main/java/edu/usc/irds/sparkler/solr/schema/StringEvaluator.java
@@ -26,7 +26,8 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 
 /**
- * Created by karanjeetsingh on 9/13/16.
+ * Created by thammegowda
+ * Modified by karanjeetsingh
  */
 public class StringEvaluator {
     private static final Logger LOG = LoggerFactory.getLogger(StringEvaluator.class);

--- a/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/StatusUpdateSolrTransformer.scala
+++ b/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/StatusUpdateSolrTransformer.scala
@@ -48,7 +48,6 @@ object StatusUpdateSolrTransformer extends (CrawlData => SolrInputDocument ) wit
     sUpdate.setField(Constants.solr.FETCH_STATUS_CODE, data.fetchedData.getResponseCode)
     sUpdate.setField(Constants.solr.SIGNATURE, StringUtil.sha256hash(new String(data.fetchedData.getContent)))
     sUpdate.setField(Constants.solr.RELATIVE_PATH, URLUtil.reverseUrl(data.fetchedData.getResource.getUrl))
-    //FIXME: Apply URL Filter(s), if required
     sUpdate.setField(Constants.solr.OUTLINKS, data.parsedData.outlinks.toArray)
 
     var mdFields: Map[String, AnyRef] = Map()


### PR DESCRIPTION
Closes #71 and #72 

Solr doesn't provide the Upsert methodology out of the box. Created another field `dedupe_id` field in Solr which stores the `SHA256(crawl_id-url)`.

Also, commented `overrides: id` from solr-schema-map.yaml to include `id` in the field formatting for Solr. Please note that this `id` field is from Tika metadata.