### PR TITLE
Felix version conflicts fixed AND option to disable plugins

### DIFF
--- a/conf/sparkler-default.yaml
+++ b/conf/sparkler-default.yaml
@@ -22,6 +22,9 @@
 # for standalone server
 crawldb.uri: http://localhost:8983/solr/crawldb
 
+# for quick test crawls using embedded solr
+#crawldb.uri: file://conf/solr/crawldb
+
 # for cloudmode with zookeepers; Format = collectionName::zkhost1:port1,zkhost2:port2,zkhost3:port3
 # crawldb.uri: crawldb::localhost:9983
 
@@ -70,11 +73,19 @@ fetcher.server.delay: 1000
 # Discouraged to Modify unless specifically required.
 plugins.bundle.directory: ${project.parent.basedir}${file.separator}${project.bundles.directory}
 
+plugins.cache.directory: felix-cache
+
+# List of activated plugins
+plugins.active:
+    - urlfilter.regex
+    # - fetcher.jbrowser
+
 # All Plugins are listed under this tree
 plugins:
   # Regex URL Filter - Filters outlinks from a web page based on Regex
   # expressions.
   urlfilter.regex:
+    #
     # File with Regex Filter Rules
     urlfilter.regex.file: regex-urlfilter.txt
   # Regex URL Filter - Filters outlinks from a web page based on Regex

--- a/conf/sparkler-default.yaml
+++ b/conf/sparkler-default.yaml
@@ -73,8 +73,6 @@ fetcher.server.delay: 1000
 # Discouraged to Modify unless specifically required.
 plugins.bundle.directory: ${project.parent.basedir}${file.separator}${project.bundles.directory}
 
-plugins.cache.directory: felix-cache
-
 # List of activated plugins
 plugins.active:
     - urlfilter.regex
@@ -88,9 +86,9 @@ plugins:
     #
     # File with Regex Filter Rules
     urlfilter.regex.file: regex-urlfilter.txt
-  # Regex URL Filter - Filters outlinks from a web page based on Regex
-  # expressions.
+  # Fetcher jBrowser - Headless browser to fetch javascript and AJAX 
+  # based document/content.
   fetcher.jbrowser:
-    # File with Regex Filter Rules
+    # Configuration Properties
     socket.timeout: 3000
     connect.timeout: 3000

--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,8 @@
         <hbase.version>1.2.1</hbase.version>
         <solr.version>6.4.0</solr.version>
         <slf4j.version>1.7.12</slf4j.version>
-        <felix.framework.version>2.0.4</felix.framework.version>
-        <felix.core.version>1.4.0</felix.core.version>
-        <felix.main.version>5.4.0</felix.main.version>
+        <osgi.version>6.0.0</osgi.version>
+        <felix.version>5.4.0</felix.version>
         <snakeyaml.version>1.17</snakeyaml.version>
         <json.simple.version>1.1.1</json.simple.version>
         <commons.validator.version>1.5.1</commons.validator.version>

--- a/sparkler-api/src/main/java/edu/usc/irds/sparkler/Constants.java
+++ b/sparkler-api/src/main/java/edu/usc/irds/sparkler/Constants.java
@@ -77,6 +77,9 @@ public interface Constants {
 
         @ConfigKey
         String PLUGINS = "plugins";
+
+        @ConfigKey
+        String ACTIVE_PLUGINS = "plugins.active";
     }
 
 
@@ -85,6 +88,7 @@ public interface Constants {
          * Create configuration instance for Sparkler
          */
         public static SparklerConfiguration newDefaultConfig(){
+            //FIXME: needs rework!
             Yaml yaml = new Yaml();
             InputStream input = null;
             SparklerConfiguration sparklerConf = null;

--- a/sparkler-app/pom.xml
+++ b/sparkler-app/pom.xml
@@ -63,13 +63,6 @@
            <artifactId>kafka-clients</artifactId>
            <version>${kafka.version}</version>
          </dependency>
-
-        <!--<dependency>
-          <groupId>org.apache.hbase</groupId>
-          <artifactId>hbase-client</artifactId>
-          <version>${hbase.version}</version>
-        </dependency>-->
-
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
@@ -110,17 +103,17 @@
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.framework</artifactId>
-            <version>${felix.framework.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.osgi.core</artifactId>
-            <version>${felix.core.version}</version>
+            <version>${felix.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.main</artifactId>
-            <version>${felix.main.version}</version>
+            <version>${felix.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>${osgi.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>

--- a/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/Crawler.scala
+++ b/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/Crawler.scala
@@ -18,11 +18,10 @@
 package edu.usc.irds.sparkler.pipeline
 
 
-import edu.usc.irds.sparkler.{Constants, CrawlDbRDD, SparklerConfiguration, URLFilter}
+import edu.usc.irds.sparkler.{Constants, CrawlDbRDD, SparklerConfiguration}
 import edu.usc.irds.sparkler.base.{CliTool, Loggable}
 import edu.usc.irds.sparkler.model.ResourceStatus._
 import edu.usc.irds.sparkler.model.{ResourceStatus, CrawlData, Resource, SparklerJob}
-import edu.usc.irds.sparkler.service.PluginService
 import edu.usc.irds.sparkler.solr.{SolrStatusUpdate, SolrUpsert}
 import edu.usc.irds.sparkler.util.JobUtil
 import org.apache.hadoop.conf.Configuration
@@ -35,8 +34,6 @@ import org.apache.spark.{SparkConf, SparkContext}
 import org.kohsuke.args4j.Option
 import org.kohsuke.args4j.spi.StringArrayOptionHandler
 
-import scala.collection.mutable.ListBuffer
-import scala.reflect.io.File
 
 /**
   *
@@ -123,11 +120,8 @@ class Crawler extends CliTool {
     job = new SparklerJob(jobId, sparklerConf, "")
   }
   //TODO: URL normalizers
-  //TODO: URL filters
-  //TODO: Data Sink
   //TODO: Robots.txt
   //TODO: Fetcher + User Agent
-  //TODO: JS render
   //TODO: Job Id
 
   override def run(): Unit = {

--- a/sparkler-plugins/fetcher-jbrowser/pom.xml
+++ b/sparkler-plugins/fetcher-jbrowser/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.framework</artifactId>
-            <version>${felix.framework.version}</version>
+            <version>${felix.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -73,9 +73,9 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Bundle-Name>fetcher.jbrowser</Bundle-Name>
+                        <Bundle-Name>${groupId}:${artifactId}</Bundle-Name>  <!-- -->
                         <Bundle-SymbolicName>fetcher.jbrowser</Bundle-SymbolicName>
-                        <Bundle-Version>${parent.version}</Bundle-Version>
+                        <Bundle-Version>${project.parent.version}</Bundle-Version>
                         <Bundle-Activator>edu.usc.irds.sparkler.plugin.FetcherJBrowserActivator</Bundle-Activator>
                         <Import-Package>org.osgi.framework,edu.usc.irds.sparkler,edu.usc.irds.sparkler.model, org.slf4j,
                             javax.net.ssl

--- a/sparkler-plugins/fetcher-jbrowser/src/main/java/edu/usc/irds/sparkler/plugin/FetcherJBrowserActivator.java
+++ b/sparkler-plugins/fetcher-jbrowser/src/main/java/edu/usc/irds/sparkler/plugin/FetcherJBrowserActivator.java
@@ -25,7 +25,8 @@ import org.slf4j.LoggerFactory;
 
 import edu.usc.irds.sparkler.Fetcher;
 
-import java.util.Properties;
+import java.util.Dictionary;
+import java.util.Hashtable;
 
 /**
  * Loads web page on a browser and returns HTML once page is loaded.
@@ -39,7 +40,7 @@ public class FetcherJBrowserActivator implements BundleActivator {
     @Override
     public void start(BundleContext bundleContext) throws Exception {
         LOG.info("Activating FetcherJBrowser Plugin");
-        Properties prop = new Properties();
+        Dictionary<String, String> prop = new Hashtable<>();
         prop.put("Fetcher", "FetcherJBrowser");
         fetcher = new FetcherJBrowser();
         bundleContext.registerService(Fetcher.class.getName(), fetcher, prop);

--- a/sparkler-plugins/urlfilter-regex/pom.xml
+++ b/sparkler-plugins/urlfilter-regex/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.framework</artifactId>
-            <version>${felix.framework.version}</version>
+            <version>${felix.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -69,9 +69,9 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Bundle-Name>urlfilter.regex</Bundle-Name>
+                        <Bundle-Name>{groupId}:${artifactId}</Bundle-Name>
                         <Bundle-SymbolicName>urlfilter.regex</Bundle-SymbolicName>
-                        <Bundle-Version>${parent.version}</Bundle-Version>
+                        <Bundle-Version>${project.parent.version}</Bundle-Version>
                         <Bundle-Activator>edu.usc.irds.sparkler.plugin.RegexURLFilterActivator</Bundle-Activator>
                         <Import-Package>org.osgi.framework,edu.usc.irds.sparkler,edu.usc.irds.sparkler.util,org.slf4j,
                             org.apache.hadoop.conf</Import-Package>

--- a/sparkler-plugins/urlfilter-regex/src/main/java/edu/usc/irds/sparkler/plugin/RegexURLFilterActivator.java
+++ b/sparkler-plugins/urlfilter-regex/src/main/java/edu/usc/irds/sparkler/plugin/RegexURLFilterActivator.java
@@ -23,7 +23,8 @@ import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Properties;
+import java.util.Dictionary;
+import java.util.Hashtable;
 
 /**
  * Activates the RegexURL Filter Plugin and register it
@@ -37,7 +38,7 @@ public class RegexURLFilterActivator implements BundleActivator {
     @Override
     public void start(BundleContext bundleContext) throws Exception {
         LOG.info("Activating RegexURL Plugin");
-        Properties prop = new Properties();
+        Dictionary<String, String> prop = new Hashtable<>();
         prop.put("URLFilter", "RegexURLFilter");
         bundleContext.registerService(URLFilter.class.getName(), new RegexURLFilter(), prop);
     }


### PR DESCRIPTION
Changelog
- Felix versions fixed. felix 5.4 and osgi 1.4 were incompatible. Now using osgi 6.0
- No caching of bundles - edit configs to reflect changes for the immediate next run
- option to enable and disable plugins

```yaml
# List of activated plugins
plugins.active:
    - urlfilter.regex
    # - fetcher.jbrowser
```
Closes #70 
Closes #76 