### PR TITLE
Parse and Index Response headers

### DIFF
--- a/conf/solr-schema-map.yaml
+++ b/conf/solr-schema-map.yaml
@@ -25,5 +25,6 @@ typeSuffix:
   java.lang.Boolean: _b
   java.lang.Float: _f
   java.lang.Double: _d
+  java.util.Date: _dt
 
 multiValSuffix: s

--- a/conf/solr/crawldb/conf/managed-schema
+++ b/conf/solr/crawldb/conf/managed-schema
@@ -181,9 +181,26 @@
    <dynamicField name="*_ls_md" type="long" indexed="true" stored="true" multiValued="true"/>
    <dynamicField name="*_d_md" type="double" indexed="true" stored="true"/>
    <dynamicField name="*_ds_md" type="double" indexed="true" stored="true" multiValued="true"/>
+   <dynamicField name="*_dt_md" type="date" indexed="true" stored="true"/>
+   <dynamicField name="*_dts_md" type="date" indexed="true" stored="true" multiValued="true"/>
    <dynamicField name="*_b_md" type="boolean" indexed="true" stored="true"/>
    <dynamicField name="*_bs_md" type="boolean" indexed="true" stored="true" multiValued="true"/>
 
+   <!-- Header Fields -->
+   <dynamicField name="*_s_hd" type="string" indexed="true" stored="true"/>
+   <dynamicField name="*_ss_hd" type="string" indexed="true" stored="true" multiValued="true"/>
+   <dynamicField name="*_t_hd" type="text_general" indexed="true" stored="true"/>
+   <dynamicField name="*_ts_hd" type="text_general" indexed="true" stored="true" multiValued="true"/>
+   <dynamicField name="*_i_hd" type="int" indexed="true" stored="true"/>
+   <dynamicField name="*_is_hd" type="int" indexed="true" stored="true" multiValued="true"/>
+   <dynamicField name="*_l_hd" type="long" indexed="true" stored="true"/>
+   <dynamicField name="*_ls_hd" type="long" indexed="true" stored="true" multiValued="true"/>
+   <dynamicField name="*_d_hd" type="double" indexed="true" stored="true"/>
+   <dynamicField name="*_ds_hd" type="double" indexed="true" stored="true" multiValued="true"/>
+   <dynamicField name="*_dt_hd" type="date" indexed="true" stored="true"/>
+   <dynamicField name="*_dts_hd" type="date" indexed="true" stored="true" multiValued="true"/>
+   <dynamicField name="*_b_hd" type="boolean" indexed="true" stored="true"/>
+   <dynamicField name="*_bs_hd" type="boolean" indexed="true" stored="true" multiValued="true"/>
    
    <dynamicField name="*_i"  type="int"    indexed="true"  stored="true"/>
    <dynamicField name="*_is" type="int"    indexed="true"  stored="true"  multiValued="true"/>
@@ -248,7 +265,21 @@
   <copyField source="*_ls_md" dest="text"/>
   <copyField source="*_d_md" dest="text"/>
   <copyField source="*_ds_md" dest="text"/>
+  <copyField source="*_dt_md" dest="text"/>
+  <copyField source="*_dts_md" dest="text"/>
 
+  <copyField source="*_s_hd" dest="text"/>
+  <copyField source="*_ss_hd" dest="text"/>
+  <copyField source="*_t_hd" dest="text"/>
+  <copyField source="*_ts_hd" dest="text"/>
+  <copyField source="*_i_hd" dest="text"/>
+  <copyField source="*_is_hd" dest="text"/>
+  <copyField source="*_l_hd" dest="text"/>
+  <copyField source="*_ls_hd" dest="text"/>
+  <copyField source="*_d_hd" dest="text"/>
+  <copyField source="*_ds_hd" dest="text"/>
+  <copyField source="*_dt_hd" dest="text"/>
+  <copyField source="*_dts_hd" dest="text"/>
 
    <!-- <copyField source="title" dest="text"/> -->
    <!-- <copyField source="plainText" dest="text"/> -->

--- a/sparkler-api/src/main/java/edu/usc/irds/sparkler/Constants.java
+++ b/sparkler-api/src/main/java/edu/usc/irds/sparkler/Constants.java
@@ -138,7 +138,6 @@ public interface Constants {
          * TODO:Should come from Sparler Config
          */
         String FELIX_CONFIG = "felix-config.properties";
-
     }
 
 
@@ -163,6 +162,7 @@ public interface Constants {
         String RELATIVE_PATH = "relative_path";
         String DEDUPE_ID = "dedupe_id";
         String MD_SUFFIX = "_md";
+        String HDR_SUFFIX = "_hd";
     }
 
 }

--- a/sparkler-api/src/main/java/edu/usc/irds/sparkler/model/FetchedData.java
+++ b/sparkler-api/src/main/java/edu/usc/irds/sparkler/model/FetchedData.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.nutch.metadata.Metadata;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -33,7 +34,7 @@ public class FetchedData implements Serializable {
     private byte[] content;
     private String contentType;
     private Integer contentLength;
-    private Map<String, List<String>> headers;
+    private Map<String, List<String>> headers = Collections.emptyMap();
     private Date fetchedAt;
     private Metadata metadata;
     private int responseCode;

--- a/sparkler-api/src/main/java/edu/usc/irds/sparkler/solr/schema/FieldMapper.java
+++ b/sparkler-api/src/main/java/edu/usc/irds/sparkler/solr/schema/FieldMapper.java
@@ -159,17 +159,14 @@ public class FieldMapper {
      */
     public Map<String, Object> mapFields(Map<String, Object> fields, boolean eval){
         Map<String, Object> result = new HashMap<>();
-
-        fields.forEach((k,v) ->{
-            if (eval && evaluator.canEval(v)) {
-                v = evaluator.eval(v);
+        fields.forEach((k, v) ->{
+            if (k != null) {
+                if (eval && evaluator.canEval(v)) {
+                    v = evaluator.eval(v);
+                }
+                result.put(mapField(k, v), v);
             }
-            result.put(mapField(k, v), v);
         });
         return result;
     }
-
-
-
-
 }

--- a/sparkler-app/src/main/scala/edu/usc/irds/sparkler/model/ParsedData.scala
+++ b/sparkler-app/src/main/scala/edu/usc/irds/sparkler/model/ParsedData.scala
@@ -26,4 +26,5 @@ class ParsedData extends Serializable {
   var extractedText: String = _
   var outlinks: Set[String] = Set.empty[String]
   var metadata: Metadata = new Metadata()
+  var headers: Map[String, AnyRef] = Map.empty
 }

--- a/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/Crawler.scala
+++ b/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/Crawler.scala
@@ -34,7 +34,6 @@ import org.apache.spark.{SparkConf, SparkContext}
 import org.kohsuke.args4j.Option
 import org.kohsuke.args4j.spi.StringArrayOptionHandler
 
-
 /**
   *
   * @since 5/28/16
@@ -216,6 +215,7 @@ object Crawler extends Loggable with Serializable{
   }
 
   def main(args: Array[String]): Unit = {
-    new Crawler().run(args)
+    val args2 = "-id test".split(" ")
+    new Crawler().run(args2)
   }
 }

--- a/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/Crawler.scala
+++ b/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/Crawler.scala
@@ -215,7 +215,6 @@ object Crawler extends Loggable with Serializable{
   }
 
   def main(args: Array[String]): Unit = {
-    val args2 = "-id test".split(" ")
-    new Crawler().run(args2)
+    new Crawler().run(args)
   }
 }

--- a/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/ParseFunction.scala
+++ b/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/ParseFunction.scala
@@ -19,6 +19,8 @@ package edu.usc.irds.sparkler.pipeline
 
 import java.io.ByteArrayInputStream
 import java.text.{ParseException, SimpleDateFormat}
+import java.util
+import java.util.Date
 
 import edu.usc.irds.sparkler.base.Loggable
 import edu.usc.irds.sparkler.model.{CrawlData, ParsedData}
@@ -26,13 +28,10 @@ import org.apache.commons.io.IOUtils
 import org.apache.tika.metadata.Metadata
 import org.apache.tika.parser.AutoDetectParser
 import org.apache.tika.sax.{BodyContentHandler, LinkContentHandler, WriteOutContentHandler}
-import java.util
 
-import java.util.Date
-
-import scala.collection.mutable
-import scala.collection.JavaConverters._
 import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
+import scala.collection.mutable
 
 /**
   * This is a transformation function for transforming raw data from crawler to parsed data

--- a/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/ParseFunction.scala
+++ b/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/ParseFunction.scala
@@ -18,7 +18,7 @@
 package edu.usc.irds.sparkler.pipeline
 
 import java.io.ByteArrayInputStream
-import java.net.HttpURLConnection
+import java.text.{ParseException, SimpleDateFormat}
 
 import edu.usc.irds.sparkler.base.Loggable
 import edu.usc.irds.sparkler.model.{CrawlData, ParsedData}
@@ -26,17 +26,18 @@ import org.apache.commons.io.IOUtils
 import org.apache.tika.metadata.Metadata
 import org.apache.tika.parser.AutoDetectParser
 import org.apache.tika.sax.{BodyContentHandler, LinkContentHandler, WriteOutContentHandler}
+import java.util
 
+import java.util.Date
+
+import scala.collection.mutable
 import scala.collection.JavaConverters._
+import scala.collection.JavaConversions._
 
 /**
   * This is a transformation function for transforming raw data from crawler to parsed data
   */
 object ParseFunction extends ((CrawlData) => (ParsedData)) with Serializable with Loggable {
-  val redirectStatuses = Set(
-    HttpURLConnection.HTTP_MOVED_PERM,
-    HttpURLConnection.HTTP_MOVED_TEMP,
-    HttpURLConnection.HTTP_SEE_OTHER)
 
   override def apply(data: CrawlData): (ParsedData) = {
     val parseData = new ParsedData()
@@ -47,21 +48,20 @@ object ParseFunction extends ((CrawlData) => (ParsedData)) with Serializable wit
     val outHandler = new WriteOutContentHandler()
     val contentHandler = new BodyContentHandler(outHandler)
     LOG.info("PARSING  {}", data.fetchedData.getResource.getUrl)
+
+    // parse outlinks
     try {
       // Parse OutLinks
       meta.set("resourceName", data.fetchedData.getResource.getUrl)
       parser.parse(stream, linkHandler, meta)
       parseData.outlinks = linkHandler.getLinks.asScala.map(_.getUri.trim).filter(!_.isEmpty).toSet
-      if (data.fetchedData.getHeaders.containsKey("Location")) {
-        // redirect
-        val redirectUrls = data.fetchedData.getHeaders.get("Location")
-        parseData.outlinks ++= redirectUrls.asScala.filter(u => u != null && !u.isEmpty)
-      }
     } catch {
       case e: Throwable =>
         LOG.warn("PARSING-OUTLINKS-ERROR {}", data.fetchedData.getResource.getUrl)
         LOG.warn(e.getMessage, e)
     } finally { IOUtils.closeQuietly(stream) }
+
+    //parse main text content
     try {
       meta = new Metadata
       meta.set("resourceName", data.fetchedData.getResource.getUrl)
@@ -70,12 +70,55 @@ object ParseFunction extends ((CrawlData) => (ParsedData)) with Serializable wit
       parser.parse(stream, contentHandler, meta)
       parseData.extractedText = outHandler.toString
       parseData.metadata = meta
-      parseData
     } catch {
       case e: Throwable =>
         LOG.warn("PARSING-CONTENT-ERROR {}", data.fetchedData.getResource.getUrl)
         LOG.warn(e.getMessage, e)
         parseData
     } finally { IOUtils.closeQuietly(stream) }
+
+    // parse headers
+    val headers = data.fetchedData.getHeaders
+    if (headers.containsKey("Location")) {   // redirect
+      val redirectUrls = headers.get("Location")
+      parseData.outlinks ++= redirectUrls.asScala.filter(u => u != null && !u.isEmpty)
+    }
+    parseData.headers = parseHeaders(headers)
+    parseData
   }
+
+  def parseHeaders(headers: util.Map[String, util.List[String]]): Map[String, AnyRef] = {
+    val dateHeaders = Set("Date", "Last-Modified", "Expires")
+    val intHeaders = Set("ContentLength")
+    val dateFmt = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz")
+
+    val result = mutable.Map[String, AnyRef]()
+    for (name <- headers.keySet()) {
+      val values = headers.get(name)
+      var parsed: AnyRef = values
+      if (values.size() == 1){
+        val value = values.get(0)
+        parsed = value
+        try {
+          if (dateHeaders contains name) {
+            parsed = parseDate(value)
+          } else if (intHeaders contains name) {
+            parsed = new java.lang.Long(value.toLong)
+          }
+        } catch {
+          case e: Exception => LOG.debug(e.getMessage, e)
+        } finally {
+          result(name) = parsed
+        }
+      }
+    }
+    result.toMap
+  }
+
+  /**
+    * Parse date string as per RFC7231 https://tools.ietf.org/html/rfc7231#section-7.1.1.1
+    */
+  val httpDateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz")
+  @throws[ParseException] //but be aware of errors
+  def parseDate(dateStr:String): Date = httpDateFormat.parse(dateStr.trim)
 }

--- a/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/StatusUpdateSolrTransformer.scala
+++ b/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/StatusUpdateSolrTransformer.scala
@@ -17,23 +17,26 @@
 
 package edu.usc.irds.sparkler.pipeline
 
-import java.util.Date
+import java.util
 
 import com.google.common.hash.{HashFunction, Hashing}
 import edu.usc.irds.sparkler.Constants
-import edu.usc.irds.sparkler.model.{CrawlData, Resource}
+import edu.usc.irds.sparkler.base.Loggable
+import edu.usc.irds.sparkler.model.CrawlData
 import edu.usc.irds.sparkler.solr.schema.FieldMapper
-import edu.usc.irds.sparkler.util.{StringUtil, URLUtil}
+import edu.usc.irds.sparkler.util.URLUtil
 import org.apache.solr.common.SolrInputDocument
 
+import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
-import scala.collection.mutable
 
 /**
   * Created by thammegr on 6/7/16.
   * Modified by karanjeets
   */
-object StatusUpdateSolrTransformer extends (CrawlData => SolrInputDocument ) with Serializable {
+object StatusUpdateSolrTransformer extends (CrawlData => SolrInputDocument ) with Serializable with Loggable {
+
+  val fieldMapper: FieldMapper = FieldMapper.initialize()
 
   override def apply(data: CrawlData): SolrInputDocument = {
     val hashFunction: HashFunction = Hashing.sha256()
@@ -43,9 +46,8 @@ object StatusUpdateSolrTransformer extends (CrawlData => SolrInputDocument ) wit
     sUpdate.setField(Constants.solr.ID, data.fetchedData.getResource.getId)
     sUpdate.setField(Constants.solr.STATUS, Map("set" -> data.fetchedData.getResource.getStatus).asJava)
     sUpdate.setField(Constants.solr.FETCH_TIMESTAMP, Map("set" -> data.fetchedData.getFetchedAt).asJava)
-    sUpdate.setField(Constants.solr.LAST_UPDATED_AT, Map("set" -> new Date()).asJava)
+    sUpdate.setField(Constants.solr.LAST_UPDATED_AT, Map("set" -> new util.Date()).asJava)
     sUpdate.setField(Constants.solr.RETRIES_SINCE_FETCH, Map("inc" -> 1).asJava)
-    //sUpdate.setField(Constants.solr.NUM_FETCHES, Map("inc" -> 1).asJava)
     sUpdate.setField(Constants.solr.EXTRACTED_TEXT, data.parsedData.extractedText)
     sUpdate.setField(Constants.solr.CONTENT_TYPE, data.fetchedData.getContentType.split("; ")(0))
     sUpdate.setField(Constants.solr.FETCH_STATUS_CODE, data.fetchedData.getResponseCode)
@@ -53,20 +55,18 @@ object StatusUpdateSolrTransformer extends (CrawlData => SolrInputDocument ) wit
     sUpdate.setField(Constants.solr.RELATIVE_PATH, URLUtil.reverseUrl(data.fetchedData.getResource.getUrl))
     sUpdate.setField(Constants.solr.OUTLINKS, data.parsedData.outlinks.toArray)
 
-    var mdFields: Map[String, AnyRef] = Map()
-    for (name: String <- data.parsedData.metadata.names()) {
-      mdFields += (name -> (if (data.parsedData.metadata.isMultiValued(name)) data.parsedData.metadata.getValues(name) else data.parsedData.metadata.get(name)))
-    }
-    val fieldMapper: FieldMapper = FieldMapper.initialize()
-    val mappedMdFields: mutable.Map[String, AnyRef] = fieldMapper.mapFields(mdFields.asJava, true).asScala
-    mappedMdFields.foreach{case (k, v) => {
-      var key: String = k
-      if (!k.endsWith(Constants.solr.MD_SUFFIX)) {
-        key = k + Constants.solr.MD_SUFFIX
-      }
-      sUpdate.setField(key, v)
-    }}
-
+    val md = data.parsedData.metadata
+    val mdFields = md.names().map(name => (name, if (md.isMultiValued(name)) md.getValues(name) else md.get(name))).toMap
+    updateFields(mdFields, Constants.solr.MD_SUFFIX, sUpdate)
+    updateFields(data.parsedData.headers, Constants.solr.HDR_SUFFIX, sUpdate)
     sUpdate
+  }
+
+  def updateFields(dict: Map[String, AnyRef], suffix:String, solrDoc:SolrInputDocument): Unit ={
+    val mapped = fieldMapper.mapFields(dict, true)
+    for (k <- mapped.keySet()) {
+      val key = if (suffix == null || suffix.isEmpty || k.endsWith(suffix)) k else k + suffix
+      solrDoc.setField(key, mapped(k))
+    }
   }
 }

--- a/sparkler-app/src/main/scala/edu/usc/irds/sparkler/solr/SolrStatusUpdate.scala
+++ b/sparkler-app/src/main/scala/edu/usc/irds/sparkler/solr/SolrStatusUpdate.scala
@@ -17,9 +17,8 @@
 
 package edu.usc.irds.sparkler.solr
 
-import org.slf4j.LoggerFactory
 import SolrStatusUpdate.LOG
-
+import edu.usc.irds.sparkler.base.Loggable
 import edu.usc.irds.sparkler.model.SparklerJob
 import org.apache.spark.TaskContext
 import org.apache.solr.common.SolrInputDocument
@@ -39,6 +38,4 @@ class SolrStatusUpdate(job: SparklerJob) extends ((TaskContext, Iterator[SolrInp
   }
 }
 
-object SolrStatusUpdate {
-  val LOG = LoggerFactory.getLogger(SolrStatusUpdate.getClass())
-}
+object SolrStatusUpdate extends Loggable;


### PR DESCRIPTION
Changelog:

Fetcher: carries forward the header
Parser: Parses common headers that require parsing, eg: dates, long/ints
Solr: Indexes headers as dynamic field (ends with suffix `_hd`)

Note: Schema update required since new dynamic fields are added for headers


Closes #89