### PR TITLE
fetcher.htmlunit - Fetcher plugin based on HTML Unit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: java
 jdk:
   - oraclejdk8
+before_install: 
+  - sudo rm /etc/mavenrc
+  - export M2_HOME=/usr/local/maven
+  - export MAVEN_OPTS="-Dmaven.repo.local=$HOME/.m2/repository -Xms1024m -Xmx3072m -XX:PermSize=512m"

--- a/conf/felix-config.properties
+++ b/conf/felix-config.properties
@@ -101,6 +101,7 @@ felix.log.level=1
 #obr.repository.url=http://felix.apache.org/obr/releases.xml
 
 org.osgi.framework.system.packages.extra=edu.usc.irds.sparkler; version=0.1,edu.usc.irds.sparkler.util; version=0.1,\
-  edu.usc.irds.sparkler.model; version=0.1,org.slf4j; version=1.7.12,org.apache.hadoop.conf; version=2.2.0, \
+  edu.usc.irds.sparkler.model; version=0.1,org.slf4j; version=1.7.25,org.slf4j.spi; version=1.7.25,\
+  org.apache.hadoop.conf; version=2.2.0,javax.net; version=1.8,\
   javax.net.ssl; version=1.8,com.sun.webkit.network; version=1.8,com.sun.webkit.network.data; version=1.8,\
   net.jcip.annotations; version=1.8,net.sf.cglib.proxy; version=1.8,com.machinepublishers.jbrowserdriver; version=0.16.4

--- a/conf/sparkler-default.yaml
+++ b/conf/sparkler-default.yaml
@@ -86,7 +86,8 @@ plugins.bundle.directory: ${project.parent.basedir}${file.separator}${project.bu
 # List of activated plugins
 plugins.active:
     - urlfilter.regex
-    # - fetcher.jbrowser
+# - fetcher.jbrowser
+    - fetcher.htmlunit
 
 # All Plugins are listed under this tree
 plugins:

--- a/pom.xml
+++ b/pom.xml
@@ -57,10 +57,10 @@
         <tika.version>1.14</tika.version>
     </properties>
     <modules>
-        <module>sparkler-tests-base</module>
         <module>sparkler-api</module>
         <module>sparkler-app</module>
         <module>sparkler-plugins</module>
+        <module>sparkler-tests-base</module>
     </modules>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <kafka.version>0.10.0.0</kafka.version>
         <hbase.version>1.2.1</hbase.version>
         <solr.version>6.4.0</solr.version>
-        <slf4j.version>1.7.12</slf4j.version>
+        <slf4j.version>1.7.25</slf4j.version>
         <osgi.version>6.0.0</osgi.version>
         <felix.version>5.4.0</felix.version>
         <snakeyaml.version>1.17</snakeyaml.version>
@@ -57,12 +57,21 @@
         <tika.version>1.14</tika.version>
     </properties>
     <modules>
+        <module>sparkler-tests-base</module>
         <module>sparkler-api</module>
         <module>sparkler-app</module>
         <module>sparkler-plugins</module>
-        <module>sparkler-tests-base</module>
     </modules>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <build>
         <plugins>
             <plugin>

--- a/sparkler-api/src/main/java/edu/usc/irds/sparkler/AbstractExtensionPoint.java
+++ b/sparkler-api/src/main/java/edu/usc/irds/sparkler/AbstractExtensionPoint.java
@@ -33,11 +33,6 @@ public abstract class AbstractExtensionPoint implements ExtensionPoint {
     protected JobContext jobContext;
     protected String pluginId;
 
-    @Override
-    public void init(JobContext context) throws SparklerException {
-        this.jobContext = context;
-        LOG.debug("Initialize the context");
-    }
 
     @Override
     public void init(JobContext context, String pluginId) throws SparklerException {

--- a/sparkler-api/src/main/java/edu/usc/irds/sparkler/ExtensionPoint.java
+++ b/sparkler-api/src/main/java/edu/usc/irds/sparkler/ExtensionPoint.java
@@ -26,13 +26,6 @@ public interface ExtensionPoint {
     /**
      * Initialize the extension
      * @param context job context
-     * @throws SparklerException when an error occurs
-     */
-    void init(JobContext context) throws SparklerException;
-
-    /**
-     * Initialize the extension
-     * @param context job context
      * @param pluginId osgi bundle symbolic name
      * @throws SparklerException when an error occurs
      */

--- a/sparkler-api/src/main/java/edu/usc/irds/sparkler/model/FetchedData.java
+++ b/sparkler-api/src/main/java/edu/usc/irds/sparkler/model/FetchedData.java
@@ -91,6 +91,30 @@ public class FetchedData implements Serializable {
         this.resource = resource;
     }
 
+    public void setContentLength(Integer contentLength) {
+        this.contentLength = contentLength;
+    }
+
+    public void setContent(byte[] content) {
+        this.content = content;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public void setFetchedAt(Date fetchedAt) {
+        this.fetchedAt = fetchedAt;
+    }
+
+    public void setMetadata(Metadata metadata) {
+        this.metadata = metadata;
+    }
+
+    public void setResponseCode(int responseCode) {
+        this.responseCode = responseCode;
+    }
+
     // TODO: Move this to Util package
     public org.apache.nutch.protocol.Content toNutchContent(Configuration conf) {
         return new org.apache.nutch.protocol.Content(resource.getUrl(), resource.getUrl(), content, contentType, metadata, conf);

--- a/sparkler-api/src/main/java/edu/usc/irds/sparkler/model/Resource.java
+++ b/sparkler-api/src/main/java/edu/usc/irds/sparkler/model/Resource.java
@@ -77,7 +77,7 @@ public class Resource implements Serializable {
 
     @Override
     public String toString() {
-        return String.format("Resource(%s, $s, %s, %s, %s, %s, %s, %s)",
+        return String.format("Resource(%s, %s, %s, %d, %f, %s)",
                 id, group, fetchTimestamp, discoverDepth, score, status);
                 //id, group, fetchTimestamp, numTries, numFetches, discoverDepth, score, status);
     }

--- a/sparkler-api/src/main/java/edu/usc/irds/sparkler/util/FetcherDefault.java
+++ b/sparkler-api/src/main/java/edu/usc/irds/sparkler/util/FetcherDefault.java
@@ -43,14 +43,16 @@ public class FetcherDefault extends AbstractExtensionPoint
     public static final Integer READ_TIMEOUT = 10000;
     public static final Integer DEFAULT_ERROR_CODE = 400;
     public static final String USER_AGENT = "User-Agent";
+    public static final Integer CONTENT_LIMIT = 100 * 1024 * 1024;
+    public static final String TRUNCATED = "X-Content-Truncated";
 
     protected List<String> userAgents;
     protected int userAgentIndex = 0; // index for rotating the agents
     protected Map<String, String> httpHeaders;
 
     @Override
-    public void init(JobContext context) throws SparklerException {
-        super.init(context);
+    public void init(JobContext context, String pluginId) throws SparklerException {
+        super.init(context, pluginId);
         SparklerConfiguration conf = context.getConfiguration();
         if (conf.containsKey(Constants.key.FETCHER_USER_AGENTS)) {
             Object agents = conf.get(Constants.key.FETCHER_USER_AGENTS);

--- a/sparkler-api/src/test/java/edu/usc/irds/sparkler/util/FetcherDefaultTest.java
+++ b/sparkler-api/src/test/java/edu/usc/irds/sparkler/util/FetcherDefaultTest.java
@@ -36,11 +36,11 @@ import static junit.framework.Assert.*;
  */
 public class FetcherDefaultTest {
 
-    private FetcherDefault fetcher = new FetcherDefault();
     private JobContext job = TestUtils.JOB_CONTEXT;
+    private FetcherDefault fetcher;
     {
         try {
-            fetcher.init(job);
+            fetcher = TestUtils.newInstance(FetcherDefault.class, "");
         } catch (SparklerException e) {
             throw new RuntimeException(e);
         }

--- a/sparkler-api/src/test/resources/user-agents.txt
+++ b/sparkler-api/src/test/resources/user-agents.txt
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# User agents to be used
+# Each line contains an agent
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Sparkler/${project.version} client1
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Sparkler/${project.version} client2

--- a/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/FetchFunction.scala
+++ b/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/FetchFunction.scala
@@ -41,7 +41,7 @@ object FetchFunction
     * @param job reference to Sparkler Job Context
     */
   def init(job: SparklerJob): Unit ={
-    fetcherDefault.init(job)
+    fetcherDefault.init(job, "")
   }
 
   override def apply(job: SparklerJob, resources: Iterator[Resource])

--- a/sparkler-plugins/fetcher-htmlunit/README.md
+++ b/sparkler-plugins/fetcher-htmlunit/README.md
@@ -1,0 +1,5 @@
+# fetcher.htmlunit
+
+This plugin provides an implementation of `Fetcher` based on [HTMLUnit](http://htmlunit.sourceforge.net/) headless browser.
+
+

--- a/sparkler-plugins/fetcher-htmlunit/pom.xml
+++ b/sparkler-plugins/fetcher-htmlunit/pom.xml
@@ -57,6 +57,12 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>edu.usc.irds.sparkler</groupId>
+            <artifactId>sparkler-tests-base</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -76,6 +82,19 @@
                         <Embed-Transitive>true</Embed-Transitive>
                     </instructions>
                     <buildDirectory>${project.parent.parent.basedir}${file.separator}${project.bundles.directory}</buildDirectory>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.19.1</version>
+                <configuration>
+                    <properties>
+                        <property>
+                            <name>listener</name>
+                            <value>edu.usc.irds.sparkler.test.WebServerRunListener</value>
+                        </property>
+                    </properties>
                 </configuration>
             </plugin>
         </plugins>

--- a/sparkler-plugins/fetcher-htmlunit/pom.xml
+++ b/sparkler-plugins/fetcher-htmlunit/pom.xml
@@ -71,7 +71,7 @@
                         <Bundle-SymbolicName>fetcher.htmlunit</Bundle-SymbolicName>
                         <Bundle-Version>${project.parent.version}</Bundle-Version>
                         <Bundle-Activator>edu.usc.irds.sparkler.plugin.HtmlUnitJsFetcherActivator</Bundle-Activator>
-                        <Import-Package>org.osgi.framework,edu.usc.irds.sparkler,edu.usc.irds.sparkler.model, org.slf4j,javax.net.ssl</Import-Package>
+                        <Import-Package>org.osgi.framework,edu.usc.irds.sparkler,edu.usc.irds.sparkler.model, org.slf4j,org.slf4j.spi,javax.net.ssl,javax.net</Import-Package>
                         <Embed-Dependency>*;scope=!provided|test;artifactId=!icu4j|slf4j-api|slf4j-log4j12|nutch |snakeyaml|json-simple</Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>
                     </instructions>

--- a/sparkler-plugins/fetcher-htmlunit/pom.xml
+++ b/sparkler-plugins/fetcher-htmlunit/pom.xml
@@ -1,0 +1,83 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sparkler-plugins</artifactId>
+        <groupId>edu.usc.irds.sparkler.plugin</groupId>
+        <version>0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>fetcher-htmlunit</artifactId>
+    <packaging>bundle</packaging>
+
+    <name>fetcher-htmlunit</name>
+    <url>http://maven.apache.org</url>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <htmlunit.version>2.26</htmlunit.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.framework</artifactId>
+            <version>${felix.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.htmlunit</groupId>
+            <artifactId>htmlunit</artifactId>
+            <version>${htmlunit.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>${maven.bundle.plugin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-Name>${groupId}:${artifactId}</Bundle-Name>  <!-- -->
+                        <Bundle-SymbolicName>fetcher.htmlunit</Bundle-SymbolicName>
+                        <Bundle-Version>${project.parent.version}</Bundle-Version>
+                        <Bundle-Activator>edu.usc.irds.sparkler.plugin.HtmlUnitJsFetcherActivator</Bundle-Activator>
+                        <Import-Package>org.osgi.framework,edu.usc.irds.sparkler,edu.usc.irds.sparkler.model, org.slf4j,javax.net.ssl</Import-Package>
+                        <Embed-Dependency>*;scope=!provided|test;artifactId=!icu4j|slf4j-api|slf4j-log4j12|nutch |snakeyaml|json-simple</Embed-Dependency>
+                        <Embed-Transitive>true</Embed-Transitive>
+                    </instructions>
+                    <buildDirectory>${project.parent.parent.basedir}${file.separator}${project.bundles.directory}</buildDirectory>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/sparkler-plugins/fetcher-htmlunit/src/main/java/edu/usc/irds/sparkler/plugin/HtmlUnitFetcher.java
+++ b/sparkler-plugins/fetcher-htmlunit/src/main/java/edu/usc/irds/sparkler/plugin/HtmlUnitFetcher.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.usc.irds.sparkler.plugin;
+
+import com.gargoylesoftware.htmlunit.BrowserVersion;
+import com.gargoylesoftware.htmlunit.Page;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.WebClientOptions;
+import com.gargoylesoftware.htmlunit.WebResponse;
+import com.gargoylesoftware.htmlunit.util.NameValuePair;
+import edu.usc.irds.sparkler.JobContext;
+import edu.usc.irds.sparkler.SparklerException;
+import edu.usc.irds.sparkler.model.FetchedData;
+import edu.usc.irds.sparkler.model.Resource;
+import edu.usc.irds.sparkler.model.ResourceStatus;
+import edu.usc.irds.sparkler.util.FetcherDefault;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.BoundedInputStream;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * This class has implements {@link edu.usc.irds.sparkler.Fetcher} using
+ * <a href="http://htmlunit.sourceforge.net/"> HTMLUnit</a>.
+ *
+ */
+public class HtmlUnitFetcher extends FetcherDefault  implements AutoCloseable {
+
+    private static final Integer DEFAULT_TIMEOUT = 2000;
+    private static final Integer DEFAULT_JS_TIMEOUT = 2000;
+    private static final Logger LOG = LoggerFactory.getLogger(HtmlUnitFetcher.class);
+    private WebClient driver;
+
+    @Override
+    public void init(JobContext context, String pluginId) throws SparklerException {
+        super.init(context, pluginId);
+        //TODO: get timeouts from configurations
+        driver = new WebClient(BrowserVersion.BEST_SUPPORTED);
+        driver.setJavaScriptTimeout(DEFAULT_JS_TIMEOUT);
+        WebClientOptions options = driver.getOptions();
+        options.setCssEnabled(false);
+        options.setAppletEnabled(false);
+        options.setDownloadImages(false);
+        options.setJavaScriptEnabled(true);
+        options.setTimeout(DEFAULT_TIMEOUT);
+        options.setUseInsecureSSL(true);
+        options.setPopupBlockerEnabled(true);
+        options.setDoNotTrackEnabled(true);
+        options.setGeolocationEnabled(false);
+        options.setHistorySizeLimit(2);
+        options.setPrintContentOnFailingStatusCode(false);
+        options.setThrowExceptionOnScriptError(false);
+        options.setThrowExceptionOnFailingStatusCode(false);
+        if (this.httpHeaders != null && !this.httpHeaders.isEmpty()) {
+            LOG.info("Found {} headers", this.httpHeaders.size());
+            this.httpHeaders.forEach((name, val) -> driver.addRequestHeader(name, val));
+        } else {
+            LOG.info("No user headers found");
+        }
+    }
+
+    @Override
+    public FetchedData fetch(Resource resource) throws Exception {
+        LOG.info("HtmlUnit FETCHER {}", resource.getUrl());
+        FetchedData fetchedData;
+        try {
+            String userAgent = getUserAgent();
+            if (StringUtils.isNotBlank(userAgent)) {
+                driver.removeRequestHeader(USER_AGENT);
+                driver.addRequestHeader(USER_AGENT, userAgent);
+            }
+            Page page = driver.getPage(resource.getUrl());
+
+            WebResponse response = page.getWebResponse();
+            boolean truncated = false;
+            try (InputStream stream = response.getContentAsStream()) {
+                try (BoundedInputStream boundedStream = new BoundedInputStream(stream, CONTENT_LIMIT)) {
+                    try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+                        IOUtils.copy(boundedStream, out);
+                        fetchedData = new FetchedData(out.toByteArray(), response.getContentType(), response.getStatusCode());
+                        long contentLength = page.getWebResponse().getContentLength();
+                        if (contentLength > 0 && contentLength < Integer.MAX_VALUE) {
+                            fetchedData.setContentLength((int) contentLength);
+                            truncated = (contentLength > fetchedData.getContentLength());
+                        }
+                    }
+                }
+            }
+            resource.setStatus(ResourceStatus.FETCHED.toString());
+
+            List<NameValuePair> respHeaders = page.getWebResponse().getResponseHeaders();
+            Map<String, List<String>> headers = new HashMap<>();
+            fetchedData.setHeaders(headers);
+            if (respHeaders != null && !respHeaders.isEmpty()){
+                respHeaders.forEach(item -> {
+                    if (!headers.containsKey(item.getName())) {
+                        headers.put(item.getName(), new ArrayList<>());
+                    }
+                    headers.get(item.getName()).add(item.getValue());
+                });
+            }
+            if (truncated){ //add truncated header
+                headers.put(TRUNCATED, Collections.singletonList(Boolean.TRUE.toString()));
+            }
+        } catch (Exception e){
+            LOG.warn(e.getMessage(), e);
+            fetchedData = new FetchedData(new byte[0], "unknown/unknown", 0); // fixme: use proper status code
+            resource.setStatus(ResourceStatus.ERROR.toString());
+        }
+        fetchedData.setResource(resource);
+        return fetchedData;
+    }
+
+    public void close() {
+        if (driver != null) {
+            LOG.info("Closing the JS browser");
+            driver.close();
+            driver = null;
+        }
+    }
+}

--- a/sparkler-plugins/fetcher-htmlunit/src/main/java/edu/usc/irds/sparkler/plugin/HtmlUnitFetcher.java
+++ b/sparkler-plugins/fetcher-htmlunit/src/main/java/edu/usc/irds/sparkler/plugin/HtmlUnitFetcher.java
@@ -31,7 +31,6 @@ import edu.usc.irds.sparkler.model.ResourceStatus;
 import edu.usc.irds.sparkler.util.FetcherDefault;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.BoundedInputStream;
-import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -108,6 +107,9 @@ public class HtmlUnitFetcher extends FetcherDefault  implements AutoCloseable {
                         if (contentLength > 0 && contentLength < Integer.MAX_VALUE) {
                             fetchedData.setContentLength((int) contentLength);
                             truncated = (contentLength > fetchedData.getContentLength());
+                            if (truncated) {
+                                LOG.info("Content Truncated: {}, TotalSize={}", resource.getUrl(), contentLength);
+                            }
                         }
                     }
                 }

--- a/sparkler-plugins/fetcher-htmlunit/src/main/java/edu/usc/irds/sparkler/plugin/HtmlUnitJsFetcherActivator.java
+++ b/sparkler-plugins/fetcher-htmlunit/src/main/java/edu/usc/irds/sparkler/plugin/HtmlUnitJsFetcherActivator.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.usc.irds.sparkler.plugin;
+
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import edu.usc.irds.sparkler.Fetcher;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+/**
+ * Loads web page on a browser and returns HTML once page is loaded.
+ * Properties can be configured
+ */
+public class HtmlUnitJsFetcherActivator implements BundleActivator {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HtmlUnitJsFetcherActivator.class);
+    private HtmlUnitFetcher fetcher;
+
+    @Override
+    public void start(BundleContext bundleContext) throws Exception {
+        LOG.info("Activating HtmlUnitFetcher Plugin");
+        Dictionary<String, String> prop = new Hashtable<>();
+        prop.put("Fetcher", "HtmlUnitFetcher");
+        fetcher = new HtmlUnitFetcher();
+        bundleContext.registerService(Fetcher.class.getName(), fetcher, prop);
+    }
+
+    @Override
+    public void stop(BundleContext bundleContext) throws Exception {
+        LOG.info("Stopping HtmlUnitFetcher Plugin");
+        if (fetcher != null) {
+            fetcher.close();
+        }
+    }
+}

--- a/sparkler-plugins/fetcher-htmlunit/src/test/java/edu/usc/irds/sparkler/plugin/HtmlUnitFetcherTest.java
+++ b/sparkler-plugins/fetcher-htmlunit/src/test/java/edu/usc/irds/sparkler/plugin/HtmlUnitFetcherTest.java
@@ -21,7 +21,8 @@ import edu.usc.irds.sparkler.model.FetchedData;
 import edu.usc.irds.sparkler.model.Resource;
 import edu.usc.irds.sparkler.util.TestUtils;
 import org.junit.Test;
-import static org.junit.Assert.*;
+
+import static org.junit.Assert.assertEquals;
 
 public class HtmlUnitFetcherTest {
 
@@ -43,6 +44,18 @@ public class HtmlUnitFetcherTest {
 		FetchedData data = htmlUnitFetcher.fetch(resource);
 		assertEquals(200, data.getResponseCode());
 		assertEquals("text/html", data.getContentType());
+	}
 
-    }
+	@Test
+	public void testJavaScript() throws Exception {
+		HtmlUnitFetcher htmlUnitFetcher = TestUtils.newInstance(HtmlUnitFetcher.class, "fetcher.htmlunit");
+		Resource resource = new Resource(
+				"http://localhost:8080/res/jspage.html",
+				"localhost", TestUtils.JOB_CONTEXT);
+
+		FetchedData data = htmlUnitFetcher.fetch(resource);
+		assertEquals(200, data.getResponseCode());
+		assertEquals("text/html", data.getContentType());
+		//TODO: assert that JS was executed
+	}
 }

--- a/sparkler-plugins/fetcher-htmlunit/src/test/java/edu/usc/irds/sparkler/plugin/HtmlUnitFetcherTest.java
+++ b/sparkler-plugins/fetcher-htmlunit/src/test/java/edu/usc/irds/sparkler/plugin/HtmlUnitFetcherTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.usc.irds.sparkler.plugin;
+
+import edu.usc.irds.sparkler.model.FetchedData;
+import edu.usc.irds.sparkler.model.Resource;
+import edu.usc.irds.sparkler.util.TestUtils;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class HtmlUnitFetcherTest {
+
+
+	@Test
+	public void testJBrowserImage() throws Exception {
+		HtmlUnitFetcher htmlUnitFetcher = TestUtils.newInstance(HtmlUnitFetcher.class, "fetcher.htmlunit");
+		Resource resource = new Resource("http://nutch.apache.org/assets/img/nutch_logo_tm.png", "nutch.apache.org", TestUtils.JOB_CONTEXT);
+		FetchedData data = htmlUnitFetcher.fetch(resource);
+		assertEquals(200, data.getResponseCode());
+		assertEquals("image/png", data.getContentType());
+	}
+
+    @Test
+    public void testJBrowserHtml() throws Exception {
+    	HtmlUnitFetcher htmlUnitFetcher = TestUtils.newInstance(HtmlUnitFetcher.class, "fetcher.htmlunit");
+		Resource resource = new Resource("http://nutch.apache.org", "nutch.apache.org", TestUtils.JOB_CONTEXT);
+
+		FetchedData data = htmlUnitFetcher.fetch(resource);
+		assertEquals(200, data.getResponseCode());
+		assertEquals("text/html", data.getContentType());
+
+    }
+}

--- a/sparkler-plugins/fetcher-htmlunit/src/test/resources/log4j.properties
+++ b/sparkler-plugins/fetcher-htmlunit/src/test/resources/log4j.properties
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Root logger option
+log4j.rootLogger=WARN, stdout
+
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L [%t] - %m%n
+
+log4j.logger.edu.usc.irds=DEBUG

--- a/sparkler-plugins/fetcher-jbrowser/src/main/java/edu/usc/irds/sparkler/plugin/FetcherJBrowser.java
+++ b/sparkler-plugins/fetcher-jbrowser/src/main/java/edu/usc/irds/sparkler/plugin/FetcherJBrowser.java
@@ -42,19 +42,13 @@ public class FetcherJBrowser extends FetcherDefault {
     private JBrowserDriver driver;
 
     @Override
-    public void init(JobContext context) throws SparklerException {
-        super.init(context);
+    public void init(JobContext context, String pluginId) throws SparklerException {
+        super.init(context, pluginId);
 
         SparklerConfiguration config = jobContext.getConfiguration();
         //TODO should change everywhere 
         pluginConfig = config.getPluginConfiguration(pluginId);
         driver = createBrowserInstance();
-    }
-
-    @Override
-    public void init(JobContext context, String pluginId) throws SparklerException {
-        this.pluginId = pluginId;
-        init(context);
     }
 
     @Override

--- a/sparkler-plugins/pom.xml
+++ b/sparkler-plugins/pom.xml
@@ -34,6 +34,7 @@
         <!-- List of all the plugins -->
         <module>urlfilter-regex</module>
         <module>fetcher-jbrowser</module>
+        <module>fetcher-htmlunit</module>
     </modules>
 
     <properties>
@@ -43,6 +44,14 @@
             <groupId>edu.usc.irds.sparkler</groupId>
             <artifactId>sparkler-api</artifactId>
             <version>${project.parent.version}</version>
+            <exclusions>
+                <!--
+                <exclusion>
+                    <artifactId>nutch</artifactId>
+                    <groupId>org.apache.nutch</groupId>
+                </exclusion>
+                -->
+            </exclusions>
         </dependency>
     </dependencies>
 </project>

--- a/sparkler-plugins/urlfilter-regex/src/main/java/edu/usc/irds/sparkler/plugin/regex/RegexURLFilterBase.java
+++ b/sparkler-plugins/urlfilter-regex/src/main/java/edu/usc/irds/sparkler/plugin/regex/RegexURLFilterBase.java
@@ -92,8 +92,8 @@ public abstract class RegexURLFilterBase extends AbstractExtensionPoint implemen
     }
 
     @Override
-    public void init(JobContext context) throws SparklerException {
-        super.init(context);
+    public void init(JobContext context, String pluginId) throws SparklerException {
+        super.init(context, pluginId);
         try {
             SparklerConfiguration config = jobContext.getConfiguration();
             LinkedHashMap pluginConfig = config.getPluginConfiguration(pluginId);
@@ -102,12 +102,6 @@ public abstract class RegexURLFilterBase extends AbstractExtensionPoint implemen
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    @Override
-    public void init(JobContext context, String pluginId) throws SparklerException {
-        this.pluginId = pluginId;
-        init(context);
     }
 
     /**

--- a/sparkler-tests-base/pom.xml
+++ b/sparkler-tests-base/pom.xml
@@ -16,7 +16,6 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <junit.version>4.12</junit.version>
     <jetty.version>9.4.0.v20161208</jetty.version>
   </properties>
 
@@ -34,17 +33,18 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <version>${slf4j.version}</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/sparkler-tests-base/src/main/resources/webapp/jspage.html
+++ b/sparkler-tests-base/src/main/resources/webapp/jspage.html
@@ -27,6 +27,7 @@
   Java Script Enabled : <span id="js-ans">No</span>
   <script type="text/javascript">
     document.getElementById('js-ans').innerHTML = 'Yes'
+    console.log("JavaScript Enabled=Yes");
   </script>
 </div>
 


### PR DESCRIPTION
This PR provides headless Javascript browser and fetcher based on HTML Unit library.

It will be interesting to weigh pros and cons of htmlunit and jbrowser to see which one we should recommend users for javascript execution.


In addition, cleaned up some code related to duplicate definition of `init()` method.