### PR TITLE
Sparkler-94 Github templates for Pull requests and Issues, and contribution guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing to Sparkler
+
+Thanks for your interest in Sparkler. Our goal is to develop an efficient, scalable web crawler to help you retrieve the resources from web with ease of use.
+
+## Getting Started
+
+Sparkler's [open issues are here](https://github.com/USCDataScience/sparkler/issues). In time, we'll tag issues that would make a good first pull request for new contributors. An easy way to get started helping the project is to *file an issue*. You can do that on the Sparkler issues page by clicking on the green button at the right. Issues can include bugs to fix, features to add, or documentation that looks outdated.
+
+For some tips on contributing to open source, this [post is helpful](http://blog.smartbear.com/programming/14-ways-to-contribute-to-open-source-without-being-a-programming-genius-or-a-rock-star/).
+
+
+## Contributions
+
+Sparkler team welcomes contributions from everyone.
+
+Contributions to Sparkler should be made in the form of GitHub pull requests. Each pull request will be reviewed by a core contributor (someone with permission to land patches) and either landed in the main tree or given feedback for changes that would be required.
+
+## Pull Request Checklist
+
+- Branch from the master branch and, if needed, rebase to the current master
+  branch before submitting your pull request. If it doesn't merge cleanly with
+  master you may be asked to rebase your changes.
+
+- Commits should be as small as possible, while ensuring that each commit is
+  correct independently (i.e., each commit should compile and pass tests).
+
+- All the additional libraries, plugins you bring into the Sparkler have a license permissible to redistribute under Apache License 2.0. Ask us incase you are doubtful about a specific library.
+
+- If your patch is not getting reviewed or you need a specific person to review it, you can @-reply a reviewer asking for a review in the pull request or a comment.
+
+- Add tests relevant to the fixed bug or new feature.
+
+- **Code style:**
+
+ **Java style:** The project includes a code format file named  `eclipse-codeformat.xml` in the root directory.
+ Depending on the IDE you use, please configure the code style rules from this XML file.
+
+ ** Scala Style:** The project also includes a code format file named `scalastyle_config.xml` in the root directory.
+ Depending on the IDE you use, please configure the code style rules from this XML file. Visit http://www.scalastyle.org/
+ for more details
+
+4. **License Header:**
+
+  All source files should include Apache License 2.0 header. Refer existing source files (.java, .scala or .xml) for an example.
+
+## Conduct
+
+We follow the [The Apache Software Foundation's Code of Conduct](https://www.apache.org/foundation/policies/conduct).
+
+All code in this repository is under the Apache Software Foundation License, 2.0.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,25 @@
+#### Issue Description
+
+Please describe our issue, along with:
+- expected behavior
+- encountered behavior
+
+#### How to reproduce it
+If you are describing a bug, please describe here how to reproduce it.
+
+#### Environment and Version Information
+
+Please indicate relevant versions, including, if relevant:
+
+* Java Version
+* Spark Version
+* Operating System name and version
+
+
+#### An external links for reference
+
+If you think any other resources on internet will be helpful to understand and/or resolve this issue, please share them here.
+
+#### Contributing
+
+If you'd like to help us fix the issue by contributing some code, but would like guidance or help in doing so, please mention it!

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## What changes were proposed in this pull request?
+
+(Please fill in changes proposed in this fix)
+
+**Is this related to an already existing issue on sparkler?**  
+ If so, mention that issue by referencing its number here.
+
+**Will it close an existing issue?**  
+Say 'Closes #IssueNum' here.
+
+
+### How was this patch tested?
+
+We are particularly interested in unit tests, integration tests, manual tests you did to ensure that the patch works as expected, so briefly describe them.
+
+
+Please review
+https://github.com/USCDataScience/sparkler/blob/master/.github/CONTRIBUTING.md before opening a pull request.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 [![Join the chat at https://gitter.im/USCDataScience/sparkler](https://badges.gitter.im/USCDataScience/sparkler.svg)](https://gitter.im/USCDataScience/sparkler?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/USCDataScience/sparkler.svg?branch=master)](https://travis-ci.org/USCDataScience/sparkler)
 
-A web crawler is a bot program that fetches resources from the web for the sake of building applications like search engines, knowledge bases, etc. Sparkler (contraction of Spark-Crawler) is a new web crawler that makes use of recent advancements in distributed computing and information retrieval domains by conglomerating various Apache projects like Spark, Kafka, Lucene/Solr, Tika, and Felix. Sparkler is an extensible, highly scalable, and high-performance web crawler that is an evolution of Apache Nutch and runs on Apache Spark Cluster. 
+A web crawler is a bot program that fetches resources from the web for the sake of building applications like search engines, knowledge bases, etc. Sparkler (contraction of Spark-Crawler) is a new web crawler that makes use of recent advancements in distributed computing and information retrieval domains by conglomerating various Apache projects like Spark, Kafka, Lucene/Solr, Tika, and Felix. Sparkler is an extensible, highly scalable, and high-performance web crawler that is an evolution of Apache Nutch and runs on Apache Spark Cluster.
 
 ### NOTE:
-Sparkler is being proposed to [Apache Incubator](http://incubator.apache.org/). Review the proposal document and provide your suggestions here [here](https://docs.google.com/document/d/1SU0YESlY5JViA9ezCSPr_SSF9e9VuvyFRICupGlfUKs/edit?usp=sharing) 
+Sparkler is being proposed to [Apache Incubator](http://incubator.apache.org/). Review the proposal document and provide your suggestions here [here](https://docs.google.com/document/d/1SU0YESlY5JViA9ezCSPr_SSF9e9VuvyFRICupGlfUKs/edit?usp=sharing)
 
 ### Notable features of Sparkler are as follows:
 
@@ -25,7 +25,7 @@ Click here for quick start guide : https://github.com/uscdataScience/sparkler/wi
 ### Requires
   * Apache Solr - (required at runtime) - config files (schema) are in `conf/solr` folder.
   * Apache Maven - (required to build)
-  * Apache Kafka - (optional, to stream output) 
+  * Apache Kafka - (optional, to stream output)
 
 Setup instructions https://github.com/uscdataScience/sparkler/wiki/sparkler-0.1#requirements
 
@@ -33,7 +33,7 @@ Setup instructions https://github.com/uscdataScience/sparkler/wiki/sparkler-0.1#
  To build this project, `cd` to the root directory of the sparkler and run the following command:
 
      mvn clean install
- 
+
  Note that this is a multi-module maven project with OSGI bundle support using Apache Felix.
  On success, the build produces `sparkler-app/target/sparkler-app-xx.jar`
  For detailed instuctions, visit the [wiki page: Build and Deploy](https://github.com/USCDataScience/sparkler/wiki/Build-and-Deploy)
@@ -61,31 +61,8 @@ This is a multi module maven project
 |fetcher-jbrowser | /sparkler-plugins/fetcher-jbrowser | This plugin use headless browser to fetch a URL | An OSGI bundle which helps to fetch Javascript enabled pages |
 
 
-### Contributing to Sparkler
-1. **Code style:**
-
- **a) Java style:** The project includes a code format file named  `eclipse-codeformat.xml` in the root directory.
- Depending on the IDE you use, please configure the code style rules from this XML file.
-
- **b) Scala Style:** The project also includes a code format file named `scalastyle_config.xml` in the root directory.
- Depending on the IDE you use, please configure the code style rules from this XML file. Visit http://www.scalastyle.org/
- for more details
-
-2. **Reporting bugs or requesting features:**
-
-   Create an issue in github, https://github.com/uscdataScience/sparkler/issues
-
-3. **Sending pull request:**
-
-  Use github pull request functionality. All pull requests must be raised against `develop` branch and have an issue created to discuss about it (for the sake of visibility to other members) whether it is bug fix or a feature addition.
-4. **Licence Header:**
-
-  All source files should include Apache Licence 2.0 licence header. Refer existing source files for an example.
-
-
 ### Contact Us
 
 In case you have any questions or suggestions, please drop them at [irds-l@mymaillists.usc.edu](mailto:irds-l@mymaillists.usc.edu)
 
 Website: [http://irds.usc.edu](http://irds.usc.edu)
-


### PR DESCRIPTION
This pull request adds Contribution guidelines and templates in `.github/` directory which will be used by github while creating Issues and pull requests.

Closes #94 

# Tests
Not Applicable, these are markdown added to help github experience and hence no changes to code


P.S.
The templates are derived from [deeplearning4j/deeplearning4j](https://github.com/deeplearning4j/deeplearning4j/tree/master/.github). So a shout-out to them with big thanks and a  :1st_place_medal: 