### PR TITLE
fix docker - permission issues and smaller images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# ignore everything
+*
+
+# except these
+!bin
+!conf
+!resources
+!sparkler-app/bundles
+!sparkler-app/target/sparkler-app-*.jar
+!sparkler-ui/target/*.war

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ sjob-**
 Application Files
 /resources
 felix-cache/
+
+tmp*
+workspace*

--- a/bin/dockler.sh
+++ b/bin/dockler.sh
@@ -32,7 +32,7 @@ solr_port=8984
 solr_url="http://localhost:$solr_port/solr"
 spark_ui_port=4041
 spark_ui_url="http://localhost:$spark_ui_port/"
-user="root"
+user="sparkler"
 
 # check for docker
 command -v docker >/dev/null 2>&1 || { echo "Error: Require 'docker' but it is unavailable." >&2; exit 2; }
@@ -42,9 +42,9 @@ build_image(){
 
     prev_dir="$PWD"
     cd "$DIR"
-    echo "Cleaning workspace to minimize size ..."
-    mvn clean -q
-    echo "Cleaning done..."
+    echo "Building project..."
+    git submodule update --init --recursive
+    mvn package -DskipTests
     cd "$prev_dir"
 
     echo "Building a docker image with tag '$docker_tag' ..."

--- a/bin/dockler.sh
+++ b/bin/dockler.sh
@@ -48,7 +48,7 @@ build_image(){
     cd "$prev_dir"
 
     echo "Building a docker image with tag '$docker_tag' ..."
-    docker build -f "$DIR/sparkler-deployment/docker/Dockerfile" -t "$docker_tag" "$DIR/sparkler-deployment/docker"
+    docker build -f "$DIR/sparkler-deployment/docker/Dockerfile" -t "$docker_tag" "$DIR"
 
     if [ $? -ne 0 ]; then
         echo "Error: Failed"

--- a/conf/sparkler-default.yaml
+++ b/conf/sparkler-default.yaml
@@ -86,8 +86,8 @@ plugins.bundle.directory: ${project.parent.basedir}${file.separator}${project.bu
 # List of activated plugins
 plugins.active:
     - urlfilter.regex
-# - fetcher.jbrowser
-    - fetcher.htmlunit
+#    - fetcher.jbrowser
+#    - fetcher.htmlunit
 
 # All Plugins are listed under this tree
 plugins:

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <module>sparkler-app</module>
         <module>sparkler-plugins</module>
         <module>sparkler-tests-base</module>
-        <!--<module>sparkler-ui</module>-->
+        <module>sparkler-ui</module>
     </modules>
 
     <dependencyManagement>

--- a/sparkler-deployment/docker/Dockerfile
+++ b/sparkler-deployment/docker/Dockerfile
@@ -17,7 +17,7 @@
 #
 # Pull base image.
 
-FROM ubuntu
+FROM ubuntu:16.04
 
 RUN groupadd --gid 1000 sparkler && \
    useradd -M --uid 1000 --gid 1000 --home /home/sparkler sparkler

--- a/sparkler-deployment/docker/Dockerfile
+++ b/sparkler-deployment/docker/Dockerfile
@@ -23,8 +23,8 @@ RUN groupadd --gid 1000 sparkler && \
    useradd -M --uid 1000 --gid 1000 --home /home/sparkler sparkler
    
    
-RUN apt-get update && \
-    apt-get install -y software-properties-common wget git
+RUN apt-get update &&  apt-get install -y software-properties-common wget lsof emacs-nox
+# RUN apt-get update && apt-get install -y git maven emacs-nox
 
 
 RUN \
@@ -36,44 +36,40 @@ RUN \
   rm -rf /var/lib/apt/lists/* && \
   rm -rf /var/cache/oracle-jdk8-installer
 
+# needed by the Jbrowser
+RUN apt-get update && apt-get install -y --fix-missing openjfx
+
+
 # Define commonly used JAVA_HOME variable
 ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
 
-RUN apt-get update && apt-get install -y git maven emacs-nox
 
 # Define working directory.
 WORKDIR /data
 
-# Copies sparkler
-# ADD ./ /data/sparkler
-RUN git clone https://github.com/USCDataScience/sparkler /data/sparkler
-
-# Setup Solr
+## Setup Solr
 RUN wget http://archive.apache.org/dist/lucene/solr/6.6.0/solr-6.6.0.tgz -O /data/solr.tgz && \
-    cd /data/ && tar xzf /data/solr.tgz 
+    cd /data/ && tar xzf /data/solr.tgz && \
+    mv /data/solr-* /data/solr && rm /data/solr.tgz
 
-RUN mv /data/solr-* /data/solr && rm /data/solr.tgz
-RUN apt-get install lsof
+# add sparkler contents
+ADD ./ /data/sparkler
+
+# Setup bundles - fix the new path
+RUN sed -i 's/plugins.bundle.directory:.*/plugins.bundle.directory: \/data\/sparkler\/sparkler-app\/bundles/g' /data/sparkler/resources/sparkler-default.yaml
+
+
+# create solr core
 RUN /data/solr/bin/solr start -force && \
     /data/solr/bin/solr create_core -force -c crawldb -d /data/sparkler/conf/solr/crawldb/ && \
     /data/solr/bin/solr stop -force
-RUN cd /data/sparkler/sparkler-ui/banana && \
-    git submodule init && \
-    git submodule update && \
-    cd /data/sparkler/sparkler-ui/ && mvn clean package
 
-RUN cd /data/sparkler && mvn clean install -DskipTests
-
-# Setup Sparkler Web Dashboard UI
-RUN cp -r /data/sparkler/sparkler-ui/sparkler-dashboard /data/solr/server/solr-webapp/ && \
+# sparkler  ui with banana dashboard
+RUN cp -r /data/sparkler/sparkler-ui/target/sparkler-ui-*.war /data/solr/server/solr-webapp/sparkler && \
     cp /data/sparkler/conf/solr/sparkler-jetty-context.xml /data/solr/server/contexts/
 
-
-RUN apt-get update && apt-get install -y --fix-missing openjfx  # needed by the Jbrowser
-
-RUN chown -R sparkler:sparkler /data/sparkler
-
-RUN chown -R sparkler:sparkler /data/solr
+# Fix permissions
+RUN chown -R sparkler:sparkler /data/
 
 USER sparkler
 # Define default command.


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Permission issue fixed for `sparkler` reported in  #124 
2. Docker build is optimized. The maven build is run in host and then copied to docker. Reasons:
 * to share .m2/repository cache between docker builds
 * To minimize the image size (by excluding all unnecessary files)

**Is this related to an already existing issue on sparkler?**  
#124 

**Will it close an existing issue?**  
Closes #124


### How was this patch tested?

Removed all docker images using `docker rmi`
freshly built docker images.
* previously `sparkler` user didnt have permissions to edit  `/data` directory, now it has
* previously docker image was > 3GB, now it is 1.8GB
* previously docker used to freshly download all maven deps insider docker. Now maven runs outside (thus reusing .m2 cache) and then copies the final builds inside docker.

 