### PR TITLE
Fix for #128: Make SOLR query for generator configurable through yaml

### DIFF
--- a/conf/sparkler-default.yaml
+++ b/conf/sparkler-default.yaml
@@ -57,7 +57,17 @@ generate.topn: 1000
 # Type: Int. Default: 256
 generate.top.groups: 256
 
+# Define criteria for sorting the top N urls
+# Note: The name of the field to sort by should exactly match the one used in the SOLR schema
+# Type: String. Default: discover_depth asc, score asc
+generate.sortby: "discover_depth asc, score asc"
 
+
+# Specify field to use for grouping partitions in RDD
+# Default is the "group" field which represent the hostnames of the URLs being fethced
+# Note: This field should match exactly the one specified in the SOLR schema
+# Type: String. Default: group
+generate.groupby: "group"
 
 ##################### Fetcher Properties ################################
 

--- a/sparkler-api/src/main/java/edu/usc/irds/sparkler/Constants.java
+++ b/sparkler-api/src/main/java/edu/usc/irds/sparkler/Constants.java
@@ -65,6 +65,12 @@ public interface Constants {
         @ConfigKey(type = int.class)
         String GENERATE_TOP_GROUPS = "generate.top.groups";
 
+        @ConfigKey
+        String GENERATE_SORTBY = "generate.sortby";
+
+        @ConfigKey
+        String GENERATE_GROUPBY = "generate.groupby";
+
         // Fetcher Properties
         @ConfigKey(type = int.class)
         String FETCHER_SERVER_DELAY = "fetcher.server.delay";

--- a/sparkler-app/src/main/scala/edu/usc/irds/sparkler/CrawlDbRDD.scala
+++ b/sparkler-app/src/main/scala/edu/usc/irds/sparkler/CrawlDbRDD.scala
@@ -38,7 +38,8 @@ class CrawlDbRDD(sc: SparkContext,
                  sortBy: String = CrawlDbRDD.DEFAULT_ORDER,
                  generateQry: String = CrawlDbRDD.DEFAULT_FILTER_QRY,
                  maxGroups: Int = CrawlDbRDD.DEFAULT_GROUPS,
-                 topN: Int = CrawlDbRDD.DEFAULT_TOPN)
+                 topN: Int = CrawlDbRDD.DEFAULT_TOPN,
+                 groupBy: String = CrawlDbRDD.DEFAULT_GROUPBY)
   extends RDD[Resource](sc, Seq.empty) {
 
 
@@ -64,7 +65,7 @@ class CrawlDbRDD(sc: SparkContext,
     qry.set("sort", sortBy)
     qry.set("group", true)
     qry.set("group.ngroups", true)
-    qry.set("group.field", Constants.solr.GROUP)
+    qry.set("group.field", groupBy)
     qry.set("group.limit", 0)
     qry.setRows(maxGroups)
     val proxy = job.newCrawlDbSolrClient()
@@ -89,4 +90,5 @@ object CrawlDbRDD extends Loggable {
   val DEFAULT_FILTER_QRY = Constants.solr.STATUS + ":" + ResourceStatus.UNFETCHED
   val DEFAULT_GROUPS = 1000
   val DEFAULT_TOPN = 1000
+  val DEFAULT_GROUPBY = "group"
 }

--- a/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/Crawler.scala
+++ b/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/Crawler.scala
@@ -92,6 +92,12 @@ class Crawler extends CliTool {
   @Option(name = "-aj", handler = classOf[StringArrayOptionHandler], aliases = Array("--add-jars"), usage = "Add sparkler jar to spark context")
   var jarPath : Array[String] = new Array[String](0)
 
+  /* Generator options, currently not exposed via the CLI
+     and only accessible through the config yaml file
+   */
+  var sortBy: String = sparklerConf.get(Constants.key.GENERATE_SORTBY).asInstanceOf[String]
+  var groupBy: String = sparklerConf.get(Constants.key.GENERATE_GROUPBY).asInstanceOf[String]
+
   var job: SparklerJob = _
   var sc: SparkContext = _
 
@@ -138,7 +144,8 @@ class Crawler extends CliTool {
       LOG.info(s"Starting the job:$jobId, task:$taskId")
 
 
-      val rdd = new CrawlDbRDD(sc, job, maxGroups = topG, topN = topN)
+      val rdd = new CrawlDbRDD(sc, job, sortBy = sortBy, maxGroups = topG,
+        topN = topN, groupBy = groupBy)
       val fetchedRdd = rdd.map(r => (r.getGroup, r))
         .groupByKey()
         .flatMap({ case (grp, rs) => new FairFetcher(job, rs.iterator, localFetchDelay,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allows for the generator to pick the sort order, groupBy field and sortBy field from the config yaml file.

**Is this related to an already existing issue on sparkler?**  
#128 

**Will it close an existing issue?**  
Closes #128 


### How was this patch tested?
There are no unit tests for this patch. 
