### PR TITLE
Fix #130: Use Maven overlay for banana instead of git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "sparkler-ui/banana"]
-	path = sparkler-ui/banana
-	url = https://github.com/lucidworks/banana

--- a/bin/dockler.sh
+++ b/bin/dockler.sh
@@ -43,7 +43,7 @@ build_image(){
     prev_dir="$PWD"
     cd "$DIR"
     echo "Building project..."
-    git submodule update --init --recursive
+      git submodule update --init --recursive
     mvn package -DskipTests
     cd "$prev_dir"
 

--- a/sparkler-ui/pom.xml
+++ b/sparkler-ui/pom.xml
@@ -34,10 +34,15 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <banana.output.directory>${project.basedir}${file.separator}target</banana.output.directory>
-        <banana.source.directory>${project.basedir}${file.separator}banana/dist</banana.source.directory>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>com.lucidworks</groupId>
+            <artifactId>banana</artifactId>
+            <version>1.5.1</version>
+            <type>war</type>
+        </dependency>
     </dependencies>
 
     <build>
@@ -58,14 +63,12 @@
                 <version>${maven.war.plugin.version}</version>
                 <configuration>
                     <outputDirectory>${banana.output.directory}</outputDirectory>
-                    <webResources> 
-                        <resource> 
-                            <directory>${project.build.sourceDirectory}</directory> 
-                        </resource> 
-                        <resource> 
-                            <directory>${banana.source.directory}</directory> 
-                        </resource> 
-                    </webResources>
+                    <overlays>
+                        <overlay>
+                            <groupId>com.lucidworks</groupId>
+                            <artifactId>banana</artifactId>
+                        </overlay>
+                    </overlays>
                     <webXml>WEB-INF/web.xml</webXml>
                 </configuration>
             </plugin>

--- a/sparkler-ui/src/main/webapp/app/dashboards/default.json
+++ b/sparkler-ui/src/main/webapp/app/dashboards/default.json
@@ -1,0 +1,685 @@
+{
+  "title": "Sparkler Dashboard",
+  "services": {
+    "query": {
+      "idQueue": [
+        1,
+        2,
+        3,
+        4
+      ],
+      "list": {
+        "0": {
+          "query": "*:*",
+          "alias": "",
+          "color": "#7EB26D",
+          "id": 0,
+          "pin": false,
+          "type": "lucene"
+        }
+      },
+      "ids": [
+        0
+      ]
+    },
+    "filter": {
+      "idQueue": [
+        1,
+        2
+      ],
+      "list": {
+        "0": {
+          "from": "2017-01-31T05:00:00.000Z",
+          "to": "2017-02-28T04:59:59.000Z",
+          "field": "last_updated_at",
+          "type": "time",
+          "mandate": "must",
+          "active": true,
+          "alias": "",
+          "id": 0
+        }
+      },
+      "ids": [
+        0
+      ]
+    }
+  },
+  "rows": [
+    {
+      "title": "Overview",
+      "height": "50px",
+      "editable": true,
+      "collapse": false,
+      "collapsable": true,
+      "panels": [
+        {
+          "error": false,
+          "span": 5,
+          "editable": true,
+          "spyable": true,
+          "group": [
+            "default"
+          ],
+          "type": "query",
+          "label": "Search",
+          "history": [
+            "*:*",
+            "*"
+          ],
+          "remember": 10,
+          "pinned": true,
+          "query": "*",
+          "title": "Search",
+          "def_type": ""
+        },
+        {
+          "span": 3,
+          "editable": true,
+          "type": "hits",
+          "loadingEditor": false,
+          "queries": {
+            "mode": "all",
+            "ids": [
+              0
+            ],
+            "query": "q=*%3A*&fq=last_updated_at:[2017-01-31T05:00:00.000Z%20TO%202017-02-28T04:59:59.000Z]&stats=true&stats.field=id&wt=json&rows=0\n",
+            "basic_query": "",
+            "custom": ""
+          },
+          "style": {
+            "font-size": "32pt"
+          },
+          "arrangement": "horizontal",
+          "chart": "total",
+          "counter_pos": "above",
+          "donut": false,
+          "tilt": false,
+          "labels": true,
+          "spyable": true,
+          "show_queries": true,
+          "metrics": [
+            {
+              "type": "count",
+              "field": "id",
+              "decimalDigits": 0,
+              "label": "",
+              "value": "1659"
+            }
+          ],
+          "refresh": {
+            "enable": false,
+            "interval": 2
+          },
+          "title": "Total Documents"
+        },
+        {
+          "error": "",
+          "span": 4,
+          "editable": true,
+          "type": "timepicker",
+          "loadingEditor": false,
+          "status": "Stable",
+          "mode": "absolute",
+          "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h"
+          ],
+          "timespan": "15m",
+          "timefield": "last_updated_at",
+          "timeformat": "",
+          "spyable": true,
+          "refresh": {
+            "enable": false,
+            "interval": 30,
+            "min": 3
+          },
+          "filter_id": 0,
+          "time": {
+            "from": "01/31/2017 00:00:00",
+            "to": "02/27/2017 23:59:59"
+          },
+          "title": "Indexed Time"
+        }
+      ]
+    },
+    {
+      "title": "Time Series",
+      "height": "150px",
+      "editable": true,
+      "collapse": false,
+      "collapsable": true,
+      "panels": [
+        {
+          "span": 4,
+          "editable": true,
+          "type": "facet",
+          "loadingEditor": false,
+          "status": "Stable",
+          "queries": {
+            "mode": "all",
+            "ids": [
+              0
+            ],
+            "query": "q=*%3A*&fq=last_updated_at:[2017-01-31T05:00:00.000Z%20TO%202017-02-28T04:59:59.000Z]&facet=true&facet.field=crawl_id&facet.field=status&facet.field=hostname&facet.field=discover_depth&wt=json",
+            "basic_query": "q=*%3A*&fq=last_updated_at:[2017-01-31T05:00:00.000Z%20TO%202017-02-28T04:59:59.000Z]&facet=true&facet.field=crawl_id&facet.field=status&facet.field=hostname&facet.field=discover_depth",
+            "custom": ""
+          },
+          "group": "default",
+          "style": {
+            "font-size": "9pt"
+          },
+          "overflow": "min-height",
+          "fields": [
+            "crawl_id",
+            "status",
+            "hostname",
+            "discover_depth"
+          ],
+          "spyable": true,
+          "facet_limit": 10,
+          "maxnum_facets": 5,
+          "foundResults": true,
+          "header_title": "",
+          "toggle_element": null,
+          "show_queries": true,
+          "title": "Facet Search",
+          "exportSize": null,
+          "offset": 0
+        },
+        {
+          "span": 8,
+          "editable": true,
+          "type": "histogram",
+          "loadingEditor": false,
+          "mode": "count",
+          "queries": {
+            "mode": "all",
+            "ids": [
+              0
+            ],
+            "query": "q=*%3A*&wt=json&rows=0&fq=last_updated_at:[2017-01-31T05:00:00.000Z%20TO%202017-02-28T04:59:59.000Z]&facet=true&facet.range=last_updated_at&facet.range.start=2017-01-31T05:00:00.000Z&facet.range.end=2017-02-28T04:59:59.000Z&facet.range.gap=%2B12HOUR\n",
+            "custom": ""
+          },
+          "max_rows": 100000,
+          "value_field": "id",
+          "group_field": "fetch_timestamp",
+          "sum_value": false,
+          "auto_int": true,
+          "resolution": 100,
+          "interval": "12h",
+          "intervals": [
+            "auto",
+            "1s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1M",
+            "1y"
+          ],
+          "fill": 0,
+          "linewidth": 3,
+          "timezone": "browser",
+          "spyable": true,
+          "zoomlinks": true,
+          "bars": true,
+          "stack": true,
+          "points": false,
+          "lines": false,
+          "lines_smooth": false,
+          "legend": true,
+          "x-axis": true,
+          "y-axis": true,
+          "percentage": false,
+          "interactive": true,
+          "options": true,
+          "show_queries": true,
+          "tooltip": {
+            "value_type": "cumulative",
+            "query_as_alias": false
+          },
+          "refresh": {
+            "enable": false,
+            "interval": 2
+          },
+          "title": "Crawl Time Series"
+        }
+      ]
+    },
+    {
+      "title": "Query and Time Window",
+      "height": "180",
+      "editable": true,
+      "collapse": false,
+      "collapsable": true,
+      "panels": [
+        {
+          "span": 4,
+          "editable": true,
+          "type": "terms",
+          "loadingEditor": false,
+          "queries": {
+            "mode": "all",
+            "ids": [
+              0
+            ],
+            "query": "q=*%3A*&wt=json&fq=last_updated_at:[2017-01-31T05:00:00.000Z%20TO%202017-02-28T04:59:59.000Z]&facet=true&facet.field=group&facet.limit=5&facet.missing=true&f.group.facet.sort=count",
+            "custom": ""
+          },
+          "mode": "count",
+          "field": "group",
+          "stats_field": "",
+          "decimal_points": 0,
+          "exclude": [],
+          "missing": false,
+          "other": false,
+          "size": 5,
+          "sortBy": "count",
+          "order": "descending",
+          "style": {
+            "font-size": "10pt"
+          },
+          "donut": false,
+          "tilt": false,
+          "labels": true,
+          "logAxis": false,
+          "arrangement": "horizontal",
+          "chart": "bar",
+          "counter_pos": "above",
+          "exportSize": 10000,
+          "lastColor": "",
+          "spyable": true,
+          "show_queries": true,
+          "chartColors": [
+            "#7EB26D",
+            "#EAB839",
+            "#6ED0E0",
+            "#EF843C",
+            "#E24D42",
+            "#1F78C1",
+            "#BA43A9",
+            "#705DA0",
+            "#508642",
+            "#CCA300",
+            "#447EBC",
+            "#C15C17",
+            "#890F02",
+            "#0A437C",
+            "#6D1F62",
+            "#584477",
+            "#B7DBAB",
+            "#F4D598",
+            "#70DBED",
+            "#F9BA8F",
+            "#F29191",
+            "#82B5D8",
+            "#E5A8E2",
+            "#AEA2E0",
+            "#629E51",
+            "#E5AC0E",
+            "#64B0C8",
+            "#E0752D",
+            "#BF1B00",
+            "#0A50A1",
+            "#962D82",
+            "#614D93",
+            "#9AC48A",
+            "#F2C96D",
+            "#65C5DB",
+            "#F9934E",
+            "#EA6460",
+            "#5195CE",
+            "#D683CE",
+            "#806EB7",
+            "#3F6833",
+            "#967302",
+            "#2F575E",
+            "#99440A",
+            "#58140C",
+            "#052B51",
+            "#511749",
+            "#3F2B5B",
+            "#E0F9D7",
+            "#FCEACA",
+            "#CFFAFF",
+            "#F9E2D2",
+            "#FCE2DE",
+            "#BADFF4",
+            "#F9D9F9",
+            "#DEDAF7"
+          ],
+          "refresh": {
+            "enable": false,
+            "interval": 2
+          },
+          "title": "Domains"
+        },
+        {
+          "span": 4,
+          "editable": true,
+          "type": "terms",
+          "loadingEditor": false,
+          "queries": {
+            "mode": "all",
+            "ids": [
+              0
+            ],
+            "query": "q=*%3A*&wt=json&fq=last_updated_at:[2017-01-31T05:00:00.000Z%20TO%202017-02-28T04:59:59.000Z]&facet=true&facet.field=discover_depth&facet.limit=5&facet.missing=true&f.discover_depth.facet.sort=index",
+            "custom": ""
+          },
+          "mode": "count",
+          "field": "discover_depth",
+          "stats_field": "",
+          "decimal_points": 0,
+          "exclude": [],
+          "missing": false,
+          "other": false,
+          "size": 5,
+          "sortBy": "index",
+          "order": "ascending",
+          "style": {
+            "font-size": "10pt"
+          },
+          "donut": false,
+          "tilt": false,
+          "labels": true,
+          "logAxis": false,
+          "arrangement": "horizontal",
+          "chart": "bar",
+          "counter_pos": "above",
+          "exportSize": 10000,
+          "lastColor": "",
+          "spyable": true,
+          "show_queries": true,
+          "chartColors": [
+            "#7EB26D",
+            "#EAB839",
+            "#6ED0E0",
+            "#EF843C",
+            "#E24D42",
+            "#1F78C1",
+            "#BA43A9",
+            "#705DA0",
+            "#508642",
+            "#CCA300",
+            "#447EBC",
+            "#C15C17",
+            "#890F02",
+            "#0A437C",
+            "#6D1F62",
+            "#584477",
+            "#B7DBAB",
+            "#F4D598",
+            "#70DBED",
+            "#F9BA8F",
+            "#F29191",
+            "#82B5D8",
+            "#E5A8E2",
+            "#AEA2E0",
+            "#629E51",
+            "#E5AC0E",
+            "#64B0C8",
+            "#E0752D",
+            "#BF1B00",
+            "#0A50A1",
+            "#962D82",
+            "#614D93",
+            "#9AC48A",
+            "#F2C96D",
+            "#65C5DB",
+            "#F9934E",
+            "#EA6460",
+            "#5195CE",
+            "#D683CE",
+            "#806EB7",
+            "#3F6833",
+            "#967302",
+            "#2F575E",
+            "#99440A",
+            "#58140C",
+            "#052B51",
+            "#511749",
+            "#3F2B5B",
+            "#E0F9D7",
+            "#FCEACA",
+            "#CFFAFF",
+            "#F9E2D2",
+            "#FCE2DE",
+            "#BADFF4",
+            "#F9D9F9",
+            "#DEDAF7"
+          ],
+          "refresh": {
+            "enable": false,
+            "interval": 2
+          },
+          "title": "Discover Depth"
+        },
+        {
+          "span": 4,
+          "editable": true,
+          "type": "terms",
+          "loadingEditor": false,
+          "queries": {
+            "mode": "all",
+            "ids": [
+              0
+            ],
+            "query": "q=*%3A*&wt=json&fq=last_updated_at:[2017-01-31T05:00:00.000Z%20TO%202017-02-28T04:59:59.000Z]&fq=-title_t_md:a&fq=-title_t_md:an&fq=-title_t_md:the&fq=-title_t_md:about&fq=-title_t_md:and&fq=-title_t_md:by&fq=-title_t_md:301&fq=-title_t_md:302&facet=true&facet.field=title_t_md&facet.limit=5&facet.missing=true&f.title_t_md.facet.sort=count",
+            "custom": ""
+          },
+          "mode": "count",
+          "field": "title_t_md",
+          "stats_field": "",
+          "decimal_points": 0,
+          "exclude": [
+            "a",
+            "an",
+            "the",
+            "about",
+            "and",
+            "by",
+            "301",
+            "302"
+          ],
+          "missing": false,
+          "other": false,
+          "size": 5,
+          "sortBy": "count",
+          "order": "descending",
+          "style": {
+            "font-size": "10pt"
+          },
+          "donut": false,
+          "tilt": false,
+          "labels": false,
+          "logAxis": false,
+          "arrangement": "horizontal",
+          "chart": "pie",
+          "counter_pos": "above",
+          "exportSize": 10000,
+          "lastColor": "",
+          "spyable": true,
+          "show_queries": true,
+          "chartColors": [
+            "#7EB26D",
+            "#EAB839",
+            "#6ED0E0",
+            "#EF843C",
+            "#E24D42",
+            "#1F78C1",
+            "#BA43A9",
+            "#705DA0",
+            "#508642",
+            "#CCA300",
+            "#447EBC",
+            "#C15C17",
+            "#890F02",
+            "#0A437C",
+            "#6D1F62",
+            "#584477",
+            "#B7DBAB",
+            "#F4D598",
+            "#70DBED",
+            "#F9BA8F",
+            "#F29191",
+            "#82B5D8",
+            "#E5A8E2",
+            "#AEA2E0",
+            "#629E51",
+            "#E5AC0E",
+            "#64B0C8",
+            "#E0752D",
+            "#BF1B00",
+            "#0A50A1",
+            "#962D82",
+            "#614D93",
+            "#9AC48A",
+            "#F2C96D",
+            "#65C5DB",
+            "#F9934E",
+            "#EA6460",
+            "#5195CE",
+            "#D683CE",
+            "#806EB7",
+            "#3F6833",
+            "#967302",
+            "#2F575E",
+            "#99440A",
+            "#58140C",
+            "#052B51",
+            "#511749",
+            "#3F2B5B",
+            "#E0F9D7",
+            "#FCEACA",
+            "#CFFAFF",
+            "#F9E2D2",
+            "#FCE2DE",
+            "#BADFF4",
+            "#F9D9F9",
+            "#DEDAF7"
+          ],
+          "refresh": {
+            "enable": false,
+            "interval": 2
+          },
+          "title": "Terms"
+        }
+      ]
+    },
+    {
+      "title": "Results",
+      "height": "50px",
+      "editable": true,
+      "collapse": false,
+      "collapsable": true,
+      "panels": [
+        {
+          "span": 12,
+          "editable": true,
+          "type": "table",
+          "loadingEditor": false,
+          "status": "Stable",
+          "queries": {
+            "mode": "all",
+            "ids": [
+              0
+            ],
+            "query": "q=*%3A*&fq=last_updated_at:[2017-01-31T05:00:00.000Z%20TO%202017-02-28T04:59:59.000Z]&wt=json&rows=200",
+            "basic_query": "q=*%3A*&fq=last_updated_at:[2017-01-31T05:00:00.000Z%20TO%202017-02-28T04:59:59.000Z]",
+            "custom": ""
+          },
+          "size": 20,
+          "pages": 10,
+          "offset": 0,
+          "sort": [],
+          "sortable": false,
+          "group": "default",
+          "style": {
+            "font-size": "9pt"
+          },
+          "overflow": "min-height",
+          "fields": [
+            "hostname",
+            "url",
+            "title_t_md",
+            "fetch_timestamp"
+          ],
+          "important_fields": [
+            "id",
+            "crawl_id",
+            "hostname",
+            "url",
+            "extracted_text",
+            "fetch_timestamp",
+            "title_t_md"
+          ],
+          "highlight": [],
+          "header": true,
+          "paging": true,
+          "field_list": false,
+          "trimFactor": 300,
+          "normTimes": true,
+          "spyable": true,
+          "saveOption": "json",
+          "exportSize": 200,
+          "exportAll": true,
+          "displayLinkIcon": true,
+          "imageFields": [],
+          "imgFieldWidth": "auto",
+          "imgFieldHeight": "85px",
+          "show_queries": true,
+          "maxNumCalcTopFields": 20,
+          "calcTopFieldValuesFromAllData": false,
+          "refresh": {
+            "enable": false,
+            "interval": 2
+          },
+          "title": "Results"
+        }
+      ]
+    }
+  ],
+  "editable": true,
+  "index": {
+    "interval": "none",
+    "pattern": "[logstash-]YYYY.MM.DD",
+    "default": "_all"
+  },
+  "style": "dark",
+  "failover": false,
+  "panel_hints": true,
+  "loader": {
+    "save_gist": true,
+    "save_elasticsearch": true,
+    "save_local": true,
+    "save_default": true,
+    "save_temp": true,
+    "save_temp_ttl_enable": true,
+    "save_temp_ttl": "30d",
+    "load_gist": true,
+    "load_elasticsearch": true,
+    "load_elasticsearch_size": 20,
+    "load_local": true,
+    "hide": false,
+    "dropdown_collections": false,
+    "save_as_public": false
+  },
+  "solr": {
+    "server": "/solr/",
+    "core_name": "crawldb",
+    "core_list": [
+      "crawldb"
+    ],
+    "global_params": ""
+  },
+  "username": "guest"
+}


### PR DESCRIPTION
Fix #130:  Use Maven overlay for banana instead of git submodule
Remove banana folder

**Is this related to an already existing issue on sparkler?**  
#130 

**Will it close an existing issue?**  
Closes #130 

### How was this patch tested?
Tested it by cloning the my branch in a new directory and running ./bin/dockler.sh script and then navigating to the /banana dashboard page. It worked and loaded the dashboard correctly. 
Note this did not require me to use the git submodules. 

