### PR TITLE
disable redundant distribution types

### DIFF
--- a/sparkler-app/src/assembly/dep.xml
+++ b/sparkler-app/src/assembly/dep.xml
@@ -4,8 +4,9 @@
   <id>bin</id>
   <formats>
     <format>tar.gz</format>
-    <format>tar.bz2</format>
-    <format>zip</format>
+    <!-- <format>tar.bz2</format>
+     <format>zip</format>
+     -->
   </formats>
   <fileSets>
     <fileSet>


### PR DESCRIPTION
## What changes were proposed in this pull request?

disabled tar.bz2 and .zip distribution

**Is this related to an already existing issue on sparkler?**  
No


### How was this patch tested?

- manually building the project and verifying that the .bz2 and .zip are not created
- travis build log showed about 60 seconds reduction in build time

![screen shot 2017-10-15 at 1 05 46 pm](https://user-images.githubusercontent.com/1865964/31588627-ab80f27e-b1a9-11e7-8dbc-d7311fd53aa9.png)




