### PR TITLE
maven-assembly-plugin:2.5.3:single failed: group id '<>' is too big E…

### DIFF
--- a/sparkler-app/pom.xml
+++ b/sparkler-app/pom.xml
@@ -258,6 +258,7 @@
                 <version>2.5.3</version>
                 <configuration>
                     <descriptor>src/assembly/dep.xml</descriptor>
+                    <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
…rror fix

## What changes were proposed in this pull request?

Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:2.5.3:single (create-archive) on project sparkler-app: Execution create-archive of goal org.apache.maven.plugins:maven-assembly-plugin:2.5.3:single failed: group id '' is too big ( > 2097151 ) -> [Help 1]

 
 


### How was this patch tested?

Local Tested


Ref : https://stackoverflow.com/questions/30246705/mvn-failure-on-build 

Please review
https://github.com/USCDataScience/sparkler/blob/master/.github/CONTRIBUTING.md before opening a pull request.
