### PR TITLE
Sparkler 147 : Support for Chaining multiple similar plugins, eg: URLFilter

### DIFF
--- a/conf/sparkler-default.yaml
+++ b/conf/sparkler-default.yaml
@@ -98,6 +98,7 @@ fetcher.headers:
 # List of activated plugins
 plugins.active:
     - urlfilter-regex
+    - urlfilter-samehost
 #    - fetcher-jbrowser
 #    - fetcher-htmlunit
 

--- a/sparkler-app/src/main/scala/edu/usc/irds/sparkler/model/SparklerJob.scala
+++ b/sparkler-app/src/main/scala/edu/usc/irds/sparkler/model/SparklerJob.scala
@@ -20,13 +20,15 @@ package edu.usc.irds.sparkler.model
 import java.io.File
 
 import edu.usc.irds.sparkler.base.Loggable
-import edu.usc.irds.sparkler.service.SolrProxy
+import edu.usc.irds.sparkler.service.{RejectingURLFilterChain, SolrProxy}
 import edu.usc.irds.sparkler.util.JobUtil
-import edu.usc.irds.sparkler.{Constants, JobContext, SparklerConfiguration, SparklerException}
+import edu.usc.irds.sparkler._
 import org.apache.solr.client.solrj.SolrClient
 import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer
 import org.apache.solr.client.solrj.impl.{CloudSolrClient, HttpSolrClient}
 import org.apache.solr.core.CoreContainer
+
+import scala.collection.mutable
 
 /**
   *
@@ -38,6 +40,15 @@ class SparklerJob(val id: String,
   extends Serializable with JobContext with Loggable {
 
   var crawlDbUri: String = config.get(Constants.key.CRAWLDB).toString
+
+  /*
+   * mappings from extension point to extension chain
+   */
+  //TODO: we should be able to overwrite these from config file
+  val extChain: collection.mutable.HashMap[Class[_<:ExtensionPoint], Class[_<:ExtensionChain[_]]] =
+    mutable.HashMap(
+      (classOf[URLFilter], classOf[RejectingURLFilterChain])
+    )
 
   /**
     * Creates solr client based on the crawldburi
@@ -62,7 +73,7 @@ class SparklerJob(val id: String,
       val coreName = solrHomeFile.getName
       LOG.info(s"Loading Embedded Solr, Home=$solrHome, Core=$coreName")
       val coreContainer: CoreContainer = new CoreContainer(solrHome)
-      coreContainer.load
+      coreContainer.load()
       new EmbeddedSolrServer(coreContainer, coreName)
     } else if (crawlDbUri.contains("::")){
       //Expected format = collection::zkhost1:port1,zkhost2:port2

--- a/sparkler-app/src/main/scala/edu/usc/irds/sparkler/service/RejectingURLFilterChain.scala
+++ b/sparkler-app/src/main/scala/edu/usc/irds/sparkler/service/RejectingURLFilterChain.scala
@@ -22,30 +22,37 @@ import java.util
 import edu.usc.irds.sparkler.base.Loggable
 import edu.usc.irds.sparkler.{ExtensionChain, JobContext, SparklerException, URLFilter}
 
+import scala.collection.JavaConversions._
 /**
-  * If one of the URL filter rejects, then the url will be rejected
+  * This class chains a list of URLFilters.
+  *  How: If one of the URL filter rejects an url, then that url will be rejected.
   */
-class URLFilters(var extensions:util.List[URLFilter])
-    extends ExtensionChain[URLFilter]
-    with URLFilter
-    with Loggable {
+class RejectingURLFilterChain extends ExtensionChain[URLFilter]
+    with URLFilter with Loggable {
   var context: JobContext = _
+  var extensions:util.List[URLFilter] = _
 
   override def filter(url: String, parent: String): Boolean ={
-    var status = true
-    val iterator = extensions.iterator
-    while (status && iterator.hasNext){
-      try {
-        status = iterator.next().filter(url, parent)
-      } catch {
-        case e: Exception =>
+    val res = !extensions.exists(ext => {
+      try !ext.filter(url, parent)
+      catch {
+        case e:Exception =>
           LOG.warn(e.getMessage, e)
+          false // exceptions are considered non rejections
       }
-    }
-    status
+    })
+    LOG.debug(s"$res : $url <-- $parent")
+    res
   }
 
   override def getExtensions: util.List[URLFilter] = this.extensions
+  /**
+    * Setter for extensions
+    *
+    * @param extensions list of extensions
+    */
+  override def setExtensions(extensions: util.List[URLFilter]): Unit = this.extensions = extensions
+
 
   override def getMinimumRequired: Int = 0
 
@@ -59,14 +66,9 @@ class URLFilters(var extensions:util.List[URLFilter])
     */
   override def init(context: JobContext, pluginId:String): Unit = {
     this.context = context
+    LOG.info(s"Initializing ${this.getClass.getName} with ${size()} extensions: $getExtensions")
   }
 
-  /**
-    * Setter for extensions
-    *
-    * @param extensions list of extensions
-    */
-  override def setExtensions(extensions: util.List[URLFilter]): Unit = this.extensions = extensions
 }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Chaining of extensions when multiple similar extensions are enabled.
Plugin service is updated to look for such scenarios, and when feasible, it will make them all work by wrapping in a ExtensionChain.
Tested using two UrlFilters, but the interfaces and chaining approach is generalizable to other plugins too. 


**Will it close an existing issue?**  
Closes #147 

