### PR TITLE
adds response_time to solr

### DIFF
--- a/conf/solr/crawldb/conf/managed-schema
+++ b/conf/solr/crawldb/conf/managed-schema
@@ -150,6 +150,8 @@
    <field name="modified_time" type="date" indexed="true" stored="true" multiValued="false" default="NOW" />
    <field name="retries_since_fetch" type="int" indexed="true" stored="true" default="-1" multiValued="false" docValues="true" />
 
+   <field name="response_time" type="long" indexed="true" stored="true" default="0" multiValued="false" docValues="true" />
+
   <!-- Admin -->
   <field name="indexed_at" type="date" indexed="true" stored="true" multiValued="false" default="NOW" />
   <field name="last_updated_at" type="date" indexed="true" stored="true" multiValued="false" default="NOW" />

--- a/sparkler-api/src/main/java/edu/usc/irds/sparkler/Constants.java
+++ b/sparkler-api/src/main/java/edu/usc/irds/sparkler/Constants.java
@@ -140,6 +140,7 @@ public interface Constants {
         String DEDUPE_ID = "dedupe_id";
         String MD_SUFFIX = "_md";
         String HDR_SUFFIX = "_hd";
+        String RESPONSE_TIME = "response_time";
     }
 
 }

--- a/sparkler-api/src/main/java/edu/usc/irds/sparkler/model/FetchedData.java
+++ b/sparkler-api/src/main/java/edu/usc/irds/sparkler/model/FetchedData.java
@@ -35,18 +35,20 @@ public class FetchedData implements Serializable {
     private Date fetchedAt;
     private MultiMap<String, String> metadata = new MultiMap<>();
     private int responseCode;
+    private long responseTime;
 
 
     public FetchedData() {
     }
 
-    public FetchedData(byte[] content, String contentType, int responseCode) {
+    public FetchedData(byte[] content, String contentType, int responseCode, long responseTime) {
         super();
         this.content = content;
         this.contentLength = content.length;
         this.contentType = contentType;
         this.responseCode = responseCode;
         this.fetchedAt = new Date();
+        this.responseTime = responseTime;
 	}
 	
 	public String getContentType() {
@@ -110,5 +112,7 @@ public class FetchedData implements Serializable {
     public void setResponseCode(int responseCode) {
         this.responseCode = responseCode;
     }
+
+    public Long getResponseTime(){return this.responseTime;}
 
 }

--- a/sparkler-api/src/main/java/edu/usc/irds/sparkler/util/FetcherDefault.java
+++ b/sparkler-api/src/main/java/edu/usc/irds/sparkler/util/FetcherDefault.java
@@ -107,6 +107,7 @@ public class FetcherDefault extends AbstractExtensionPoint implements Fetcher, F
 
     public FetchedData fetch(Resource resource) throws Exception {
         LOG.info("DEFAULT FETCHER {}", resource.getUrl());
+        long startTime = System.currentTimeMillis();
         URLConnection urlConn = new URL(resource.getUrl()).openConnection();
         if (httpHeaders != null){
             httpHeaders.entrySet().forEach(e -> urlConn.setRequestProperty(e.getKey(), e.getValue()));
@@ -133,7 +134,8 @@ public class FetcherDefault extends AbstractExtensionPoint implements Fetcher, F
             } else {
                 rawData = new byte[0]; //no content received
             }
-            FetchedData fetchedData = new FetchedData(rawData, urlConn.getContentType(), responseCode);
+
+            FetchedData fetchedData = new FetchedData(rawData, urlConn.getContentType(), responseCode, System.currentTimeMillis() - startTime);
             resource.setStatus(ResourceStatus.FETCHED.toString());
             fetchedData.setResource(resource);
             fetchedData.setHeaders(urlConn.getHeaderFields());
@@ -152,7 +154,7 @@ public class FetcherDefault extends AbstractExtensionPoint implements Fetcher, F
             }
             LOG.warn("FETCH-ERROR {}", resource.getUrl());
             LOG.debug(e.getMessage(), e);
-            FetchedData fetchedData = new FetchedData(new byte[0], "", statusCode);
+            FetchedData fetchedData = new FetchedData(new byte[0], "", statusCode, 0);
             resource.setStatus(ResourceStatus.ERROR.toString());
             fetchedData.setResource(resource);
             return fetchedData;

--- a/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/StatusUpdateSolrTransformer.scala
+++ b/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/StatusUpdateSolrTransformer.scala
@@ -54,6 +54,7 @@ object StatusUpdateSolrTransformer extends (CrawlData => SolrInputDocument ) wit
     sUpdate.setField(Constants.solr.SIGNATURE, hashFunction.hashBytes(data.fetchedData.getContent).toString)
     sUpdate.setField(Constants.solr.RELATIVE_PATH, URLUtil.reverseUrl(data.fetchedData.getResource.getUrl))
     sUpdate.setField(Constants.solr.OUTLINKS, data.parsedData.outlinks.toArray)
+    sUpdate.setField(Constants.solr.RESPONSE_TIME, data.fetchedData.getResponseTime)
     for ((scoreKey, score) <- data.fetchedData.getResource.getScore) {
       sUpdate.setField(scoreKey, Map("set" -> score).asJava)
     }

--- a/sparkler-plugins/fetcher-htmlunit/src/main/java/edu/usc/irds/sparkler/plugin/HtmlUnitFetcher.java
+++ b/sparkler-plugins/fetcher-htmlunit/src/main/java/edu/usc/irds/sparkler/plugin/HtmlUnitFetcher.java
@@ -90,6 +90,7 @@ public class HtmlUnitFetcher extends FetcherDefault  implements AutoCloseable {
     public FetchedData fetch(Resource resource) throws Exception {
         LOG.info("HtmlUnit FETCHER {}", resource.getUrl());
         FetchedData fetchedData;
+        long startTime = System.currentTimeMillis();
         try {
             String userAgent = getUserAgent();
             if (StringUtils.isNotBlank(userAgent)) {
@@ -104,7 +105,7 @@ public class HtmlUnitFetcher extends FetcherDefault  implements AutoCloseable {
                 try (BoundedInputStream boundedStream = new BoundedInputStream(stream, CONTENT_LIMIT)) {
                     try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
                         IOUtils.copy(boundedStream, out);
-                        fetchedData = new FetchedData(out.toByteArray(), response.getContentType(), response.getStatusCode());
+                        fetchedData = new FetchedData(out.toByteArray(), response.getContentType(), response.getStatusCode(), System.currentTimeMillis() - startTime);
                         long contentLength = page.getWebResponse().getContentLength();
                         if (contentLength > 0 && contentLength < Integer.MAX_VALUE) {
                             fetchedData.setContentLength((int) contentLength);
@@ -134,7 +135,7 @@ public class HtmlUnitFetcher extends FetcherDefault  implements AutoCloseable {
             }
         } catch (Exception e){
             LOG.warn(e.getMessage(), e);
-            fetchedData = new FetchedData(new byte[0], "unknown/unknown", 0); // fixme: use proper status code
+            fetchedData = new FetchedData(new byte[0], "unknown/unknown", 0, 0); // fixme: use proper status code
             resource.setStatus(ResourceStatus.ERROR.toString());
         }
         fetchedData.setResource(resource);

--- a/sparkler-plugins/fetcher-jbrowser/src/main/java/edu/usc/irds/sparkler/plugin/FetcherJBrowser.java
+++ b/sparkler-plugins/fetcher-jbrowser/src/main/java/edu/usc/irds/sparkler/plugin/FetcherJBrowser.java
@@ -94,7 +94,7 @@ public class FetcherJBrowser extends FetcherDefault {
             LOG.info("{} Failed to fetch the page. Falling back to default fetcher.", resource.getUrl());
             return super.fetch(resource);
         }
-        fetchedData = new FetchedData(html.getBytes(), "application/html", status);
+        fetchedData = new FetchedData(html.getBytes(), "application/html", status, System.currentTimeMillis() - start);
         resource.setStatus(ResourceStatus.FETCHED.toString());
         fetchedData.setResource(resource);
         return fetchedData;


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR adds a new field to solr, "response_time" which stores the time taken
by HTTP server to provide the web page (That is the time taken from the first byte of the request to the last byte of response)
(Please fill in changes proposed in this fix)

**Is this related to an already existing issue on sparkler?**  
 If so, mention that issue by referencing its number here.
related to #144 

**Will it close an existing issue?**  
Say 'Closes #IssueNum' here.
Closes #144 

### How was this patch tested?
Manual tests were done, no new test cases added
the existing tests are kept intact
all tests passed for `mvn clean test`



Please review
https://github.com/USCDataScience/sparkler/blob/master/.github/CONTRIBUTING.md before opening a pull request.

  