### PR TITLE
Sparkler on K8S updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,3 +22,4 @@
 # except these
 !build
 !sparkler-ui/target/*.war
+!conf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 language: java
+sudo: required
+services:
+  - docker
 jdk:
   - oraclejdk8
 before_install: 
   - export MAVEN_SKIP_RC=true
   - export M2_HOME=/usr/local/maven
   - export MAVEN_OPTS="-Dmaven.repo.local=$HOME/.m2/repository -Xms1024m -Xmx3072m -XX:PermSize=512m"
+
+after_script:
+  - docker build -t buggtb/sparkler-standalone .
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,7 @@ after_script:
   - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
   - docker build . -t uscdatascience/sparkler-standalone -f sparkler-deployment/docker-k8s/Dockerfile
   - docker push uscdatascience/sparkler-standalone
+  - docker build . -t uscdatascience/sparkler -f sparkler-deployment/docker/Dockerfile
+  - docker push uscdatascience/sparkler
+  - docker build . -t uscdatascience/sparkler-init -f sparkler-deployment/sparkler-init/Dockerfile
+  - docker push uscdatascience/sparkler-init

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,6 @@ before_install:
   - export MAVEN_OPTS="-Dmaven.repo.local=$HOME/.m2/repository -Xms1024m -Xmx3072m -XX:PermSize=512m"
 
 after_script:  
+  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
   - docker build . -t buggtb/sparkler-standalone -f sparkler-deployment/docker-k8s/Dockerfile
-
+  - docker push buggtb/sparkler-standalone

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ before_install:
   - export MAVEN_OPTS="-Dmaven.repo.local=$HOME/.m2/repository -Xms1024m -Xmx3072m -XX:PermSize=512m"
 
 after_script:  
-  - docker build -t buggtb/sparkler-standalone -f sparkler-deployment/docker-k8s/Dockerfile
+  - docker build . -t buggtb/sparkler-standalone -f sparkler-deployment/docker-k8s/Dockerfile
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,5 @@ before_install:
   - export M2_HOME=/usr/local/maven
   - export MAVEN_OPTS="-Dmaven.repo.local=$HOME/.m2/repository -Xms1024m -Xmx3072m -XX:PermSize=512m"
 
-after_script:
-  - docker build -t buggtb/sparkler-standalone .
+after_script:  - docker build -t buggtb/sparkler-standalone -f sparkler-deployment/docker-k8s/Dockerfile
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,6 @@ before_install:
   - export M2_HOME=/usr/local/maven
   - export MAVEN_OPTS="-Dmaven.repo.local=$HOME/.m2/repository -Xms1024m -Xmx3072m -XX:PermSize=512m"
 
-after_script:  - docker build -t buggtb/sparkler-standalone -f sparkler-deployment/docker-k8s/Dockerfile
+after_script:  
+  - docker build -t buggtb/sparkler-standalone -f sparkler-deployment/docker-k8s/Dockerfile
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ before_install:
 
 after_script:  
   - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-  - docker build . -t buggtb/sparkler-standalone -f sparkler-deployment/docker-k8s/Dockerfile
-  - docker push buggtb/sparkler-standalone
+  - docker build . -t uscdatascience/sparkler-standalone -f sparkler-deployment/docker-k8s/Dockerfile
+  - docker push uscdatascience/sparkler-standalone

--- a/sparkler-deployment/docker-k8s/Dockerfile
+++ b/sparkler-deployment/docker-k8s/Dockerfile
@@ -1,0 +1,77 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Pull base image.
+
+# NOTE: always run docker build command from root of sparkler project
+# Build command:
+#    docker build -t sparkler-local -f sparkler-deployment/docker/Dockerfile .
+
+FROM openjdk:8
+
+RUN groupadd --gid 1000 sparkler && \
+   useradd -M --uid 1000 --gid 1000 --home /home/sparkler sparkler
+
+#RUN apt-get update &&  apt-get install -y software-properties-common wget lsof emacs-nox
+
+#RUN apt-get install -y vim
+
+#RUN apt-get install -y nano
+
+#RUN \
+#  echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
+#  apt-add-repository universe && \
+#  add-apt-repository -y ppa:webupd8team/java && \
+#  apt-get update && \
+#  apt-get install -y oracle-java8-installer && \
+#  rm -rf /var/lib/apt/lists/* && \
+#  rm -rf /var/cache/oracle-jdk8-installer
+
+# needed by the Jbrowser
+RUN apt-get update && apt-get install -y --fix-missing openjfx
+
+
+# Define commonly used JAVA_HOME variable
+#ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
+
+
+# Define working directory.
+WORKDIR /data
+
+## Setup Solr
+# RUN wget http://archive.apache.org/dist/lucene/solr/7.1.0/solr-7.1.0.tgz -O /data/solr.tgz && \
+#    cd /data/ && tar xzf /data/solr.tgz && \
+#    mv /data/solr-* /data/solr && rm /data/solr.tgz
+
+# add sparkler contents
+ADD ./build /data/sparkler
+
+# create solr core
+# RUN /data/solr/bin/solr start -force && \
+#    /data/solr/bin/solr create_core -force -c crawldb -d /data/sparkler/conf/solr/crawldb/ && \
+#    /data/solr/bin/solr stop -force
+
+# sparkler  ui with banana dashboard
+# COPY ./sparkler-ui/target/sparkler-ui-*.war /data/solr/server/solr-webapp/sparkler
+# RUN cp /data/sparkler/conf/solr/sparkler-jetty-context.xml /data/solr/server/contexts/
+
+# Fix permissions
+RUN chown -R sparkler:sparkler /data/
+
+USER sparkler
+# Define default command.
+CMD ["bash"]

--- a/sparkler-deployment/docker-k8s/Dockerfile
+++ b/sparkler-deployment/docker-k8s/Dockerfile
@@ -30,7 +30,7 @@ RUN groupadd --gid 1000 sparkler && \
 
 #RUN apt-get install -y vim
 
-RUN apt-get install -y nano
+RUN apt-get update && apt-get install -y nano
 
 #RUN \
 #  echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \

--- a/sparkler-deployment/docker-k8s/Dockerfile
+++ b/sparkler-deployment/docker-k8s/Dockerfile
@@ -30,7 +30,7 @@ RUN groupadd --gid 1000 sparkler && \
 
 #RUN apt-get install -y vim
 
-#RUN apt-get install -y nano
+RUN apt-get install -y nano
 
 #RUN \
 #  echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \

--- a/sparkler-deployment/helm/.helmignore
+++ b/sparkler-deployment/helm/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/sparkler-deployment/helm/Chart.yaml
+++ b/sparkler-deployment/helm/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Sparker. Sparkler is a distributed web crawler based on Spark and Scala
+name: sparkler
+version: 0.1.0

--- a/sparkler-deployment/helm/templates/_helpers.tpl
+++ b/sparkler-deployment/helm/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "sparkler.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "sparkler.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "sparkler.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/sparkler-deployment/helm/templates/deployment.yaml
+++ b/sparkler-deployment/helm/templates/deployment.yaml
@@ -1,0 +1,301 @@
+---
+apiVersion: v1
+data:
+  solrHome: /store/data
+  solrHost: solr-service
+  solrLogsDir: /store/logs
+  solrPort: "{{ .Values.solrCluster.port }}"
+  zkHost: zookeeper-service:{{ .Values.zookeeperCluster.port }}
+kind: ConfigMap
+metadata:
+  name: solr-config
+---
+apiVersion: v1
+data:
+  zooDataDir: /store/data
+  zooDataLogDir: /store/datalog
+  zooLogDir: /store/logs
+  zooMyId: "{{ .Values.zookeeperCluster.id }}"
+  zooPort: "{{ .Values.zookeeperCluster.port }}"
+kind: ConfigMap
+metadata:
+  name: zookeeper-config
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+   name: {{ template "sparkler.fullname" . }}
+spec:
+   replicas: {{ .Values.sparklerCluster.settings.replicaCount }}
+   template:
+     metadata:
+       labels:
+         app: {{ template "sparkler.name" . }}
+     spec:
+       containers:
+         - name: sparkler
+           image: {{ .Values.sparklerCluster.image.name }}:{{ .Values.sparklerCluster.image.dockerTag }}
+           command: ["tail", "-f", "/dev/null"]
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+   name: zookeeper-volume
+spec:
+   storageClassName: {{ .Values.zookeeperCluster.storage.className }}
+   accessModes:
+     - ReadWriteOnce
+   capacity:
+     storage: {{ .Values.zookeeperCluster.storage.capacity }}
+   hostPath:
+     path: {{ .Values.zookeeperCluster.storage.path | quote }}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+   name: solr-volume
+spec:
+   storageClassName: {{ .Values.solrCluster.solr.storage.className }}
+   accessModes:
+     - ReadWriteOnce
+   capacity:
+     storage: {{ .Values.solrCluster.solr.storage.capacity }}
+   hostPath:
+     path: {{ .Values.solrCluster.solr.storage.path | quote }}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+   name: solr-configset-volume
+spec:
+   storageClassName: {{ .Values.solrCluster.configset.storage.className }}
+   accessModes:
+     - ReadWriteOnce
+   capacity:
+     storage: {{ .Values.solrCluster.configset.storage.capacity }}
+   hostPath:
+     path: {{ .Values.solrCluster.configset.storage.path | quote }}
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+   name: task-solr-configset-pv-claim
+spec:
+   storageClassName: {{ .Values.solrCluster.configset.storage.className }}
+   accessModes:
+     - ReadWriteOnce
+   resources:
+     requests:
+       storage: {{ .Values.solrCluster.configset.storage.capacity }}
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+   name: task-zookeeper-pv-claim
+spec:
+   storageClassName: {{ .Values.zookeeperCluster.storage.className }}
+   accessModes:
+     - ReadWriteOnce
+   resources:
+     requests:
+       storage: {{ .Values.zookeeperCluster.storage.capacity }}
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+   name: task-solr-pv-claim
+spec:
+   storageClassName: {{ .Values.solrCluster.solr.storage.className }}
+   accessModes:
+     - ReadWriteOnce
+   resources:
+     requests:
+       storage: {{ .Values.solrCluster.solr.storage.capacity }}
+---
+apiVersion: apps/v1beta2
+kind: StatefulSet
+metadata:
+  name: zookeeper-ss
+spec:
+  selector:
+    matchLabels:
+      app: zookeeper-app
+  serviceName: "zookeeper-service"
+  replicas: 1 # by default is 1
+  template:
+    metadata:
+      labels:
+        app: zookeeper-app
+    spec:
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: volzookeeper
+        persistentVolumeClaim:
+          claimName: task-zookeeper-pv-claim
+      containers:
+      - name: zookeeper
+        image: {{ .Values.zookeeperCluster.image.name }}:{{ .Values.zookeeperCluster.image.dockerTag }}
+        volumeMounts:
+        - name: volzookeeper
+          mountPath: /store
+        ports:
+        - name: zookeeper-port
+          containerPort: 2181
+        env:
+          - name: ZOO_MY_ID
+            valueFrom:
+              configMapKeyRef:
+                name: zookeeper-config
+                key: zooMyId
+          - name: ZOO_LOG_DIR
+            valueFrom:
+              configMapKeyRef:
+                name: zookeeper-config
+                key: zooLogDir
+          - name: ZOO_DATA_DIR
+            valueFrom:
+              configMapKeyRef:
+                name: zookeeper-config
+                key: zooDataDir
+          - name: ZOO_DATA_LOG_DIR
+            valueFrom:
+              configMapKeyRef:
+                name: zookeeper-config
+                key: zooDataLogDir
+          - name: ZOO_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: zookeeper-config
+                key: zooPort
+      initContainers:
+      - name: init-zookeeper-data
+        image: busybox
+        command: ['sh', '-c', 'mkdir -p /store/data && chown 1000:1000 /store/data']
+        volumeMounts:
+        - name: volzookeeper
+          mountPath: /store
+      - name: init-zookeeper-logs
+        image: busybox
+        command: ['sh', '-c', 'mkdir -p /store/logs && chown 1000:1000 /store/logs']
+        volumeMounts:
+        - name: volzookeeper
+          mountPath: /store
+      - name: init-zookeeper-datalog
+        image: busybox
+        command: ['sh', '-c', 'mkdir -p /store/datalog && chown 1000:1000 /store/datalog']
+        volumeMounts:
+        - name: volzookeeper
+          mountPath: /store
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zookeeper-service
+spec:
+  ports:
+  - port: {{ .Values.zookeeperCluster.port }}
+    targetPort: {{ .Values.zookeeperCluster.port }}
+    nodePort: {{ .Values.zookeeperCluster.port }}
+    protocol: TCP
+  selector:
+    app: zookeeper-app
+  type: NodePort
+---
+apiVersion: apps/v1beta2
+kind: StatefulSet
+metadata:
+  name: solr-ss
+spec:
+  selector:
+    matchLabels:
+      app: solr-app
+  serviceName: "solr-service"
+  replicas: {{ .Values.solrCluster.settings.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: solr-app
+    spec:
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: volsolr
+        persistentVolumeClaim:
+          claimName: task-solr-pv-claim
+      - name: volconfigset
+        persistentVolumeClaim:
+          claimName: task-solr-configset-pv-claim
+      containers:
+      - name: solr
+        image: {{ .Values.solrCluster.image.name }}:{{ .Values.solrCluster.image.dockerTag }}
+        volumeMounts:
+        - name: volsolr
+          mountPath: /store
+        - name: volconfigset
+          mountPath: /opt/solr/server/solr/configsets/
+        ports:
+        - name: solr-port
+          containerPort: 2181
+        env:
+          - name: SOLR_HOME
+            valueFrom:
+              configMapKeyRef:
+                name: solr-config
+                key: solrHome
+          - name: SOLR_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: solr-config
+                key: solrPort
+          - name: ZK_HOST
+            valueFrom:
+              configMapKeyRef:
+                name: solr-config
+                key: zkHost
+          - name: SOLR_HOST
+            valueFrom:
+              configMapKeyRef:
+                name: solr-config
+                key: solrHost
+          - name: SOLR_LOGS_DIR
+            valueFrom:
+              configMapKeyRef:
+                name: solr-config
+                key: solrLogsDir
+      initContainers:
+      - name: init-solr-data
+        image: busybox
+        command: ['sh', '-c', 'mkdir -p /store/data && chown 8983:8983 /store/data']
+        volumeMounts:
+        - name: volsolr
+          mountPath: /store
+      - name: init-solr-logs
+        image: busybox
+        command: ['sh', '-c', 'mkdir -p /store/logs && chown 8983:8983 /store/logs']
+        volumeMounts:
+        - name: volsolr
+          mountPath: /store
+      - name: init-solr-xml
+        image: solr:latest
+        command: ['sh', '-c', '[ ! -f /store/data/solr.xml ] && cp /opt/solr/server/solr/solr.xml /store/data/solr.xml || true']
+        volumeMounts:
+        - name: volsolr
+          mountPath: /store
+      - name: init-solr-configset
+        image: {{ .Values.sparklerInit.image.name }}:{{ .Values.sparklerInit.image.dockerTag }}
+        volumeMounts:
+        - name: volconfigset
+          mountPath: /solr
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: solr-service
+spec:
+  ports:
+  - port: {{ .Values.solrCluster.port }}
+    targetPort: {{ .Values.solrCluster.port }}
+    nodePort: {{ .Values.solrCluster.port }}
+    protocol: TCP
+  selector:
+    app: solr-app
+  type: NodePort

--- a/sparkler-deployment/helm/test.yaml
+++ b/sparkler-deployment/helm/test.yaml
@@ -1,0 +1,304 @@
+---
+# Source: sparkler/templates/deployment.yaml
+---
+apiVersion: v1
+data:
+  solrHome: /store/data
+  solrHost: solr-service
+  solrLogsDir: /store/logs
+  solrPort: "32080"
+  zkHost: zookeeper-service:32181
+kind: ConfigMap
+metadata:
+  name: solr-config
+---
+apiVersion: v1
+data:
+  zooDataDir: /store/data
+  zooDataLogDir: /store/datalog
+  zooLogDir: /store/logs
+  zooMyId: "1"
+  zooPort: "32181"
+kind: ConfigMap
+metadata:
+  name: zookeeper-config
+---
+ apiVersion: extensions/v1beta1
+ kind: Deployment
+ metadata:
+   name: fantastic-anaconda-sparkler
+ spec:
+   replicas: 3
+   template:
+     metadata:
+       labels:
+         app: sparkler
+     spec:
+       containers:
+         - name: sparkler
+           image: buggtb/sparkler-standalone:latest
+           command: ["tail", "-f", "/dev/null"]
+---
+ apiVersion: v1
+ kind: PersistentVolume
+ metadata:
+   name: zookeeper-volume
+ spec:
+   storageClassName: manual
+   accessModes:
+     - ReadWriteOnce
+   capacity:
+     storage: 5Gi
+   hostPath:
+     path: "/data/zookeeper"
+---
+ apiVersion: v1
+ kind: PersistentVolume
+ metadata:
+   name: solr-volume
+ spec:
+   storageClassName: manual
+   accessModes:
+     - ReadWriteOnce
+   capacity:
+     storage: 5Gi
+   hostPath:
+     path: "/data/solr"
+---
+ apiVersion: v1
+ kind: PersistentVolume
+ metadata:
+   name: solr-configset-volume
+ spec:
+   storageClassName: manual
+   accessModes:
+     - ReadWriteOnce
+   capacity:
+     storage: 1Gi
+   hostPath:
+     path: "/data/solr-configset"
+---
+ kind: PersistentVolumeClaim
+ apiVersion: v1
+ metadata:
+   name: task-solr-configset-pv-claim
+ spec:
+   storageClassName: manual
+   accessModes:
+     - ReadWriteOnce
+   resources:
+     requests:
+       storage: 1Gi
+---
+ kind: PersistentVolumeClaim
+ apiVersion: v1
+ metadata:
+   name: task-zookeeper-pv-claim
+ spec:
+   storageClassName: manual
+   accessModes:
+     - ReadWriteOnce
+   resources:
+     requests:
+       storage: 5Gi
+---
+ kind: PersistentVolumeClaim
+ apiVersion: v1
+ metadata:
+   name: task-solr-pv-claim
+ spec:
+   storageClassName: manual
+   accessModes:
+     - ReadWriteOnce
+   resources:
+     requests:
+       storage: 5Gi
+---
+apiVersion: apps/v1beta2
+kind: StatefulSet
+metadata:
+  name: zookeeper-ss
+spec:
+  selector:
+    matchLabels:
+      app: zookeeper-app
+  serviceName: "zookeeper-service"
+  replicas: 1 # by default is 1
+  template:
+    metadata:
+      labels:
+        app: zookeeper-app
+    spec:
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: volzookeeper
+        persistentVolumeClaim:
+          claimName: task-zookeeper-pv-claim
+      containers:
+      - name: zookeeper
+        image: zookeeper:latest
+        volumeMounts:
+        - name: volzookeeper
+          mountPath: /store
+        ports:
+        - name: zookeeper-port
+          containerPort: 2181
+        env:
+          - name: ZOO_MY_ID
+            valueFrom:
+              configMapKeyRef:
+                name: zookeeper-config
+                key: zooMyId
+          - name: ZOO_LOG_DIR
+            valueFrom:
+              configMapKeyRef:
+                name: zookeeper-config
+                key: zooLogDir
+          - name: ZOO_DATA_DIR
+            valueFrom:
+              configMapKeyRef:
+                name: zookeeper-config
+                key: zooDataDir
+          - name: ZOO_DATA_LOG_DIR
+            valueFrom:
+              configMapKeyRef:
+                name: zookeeper-config
+                key: zooDataLogDir
+          - name: ZOO_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: zookeeper-config
+                key: zooPort
+      initContainers:
+      - name: init-zookeeper-data
+        image: busybox
+        command: ['sh', '-c', 'mkdir -p /store/data && chown 1000:1000 /store/data']
+        volumeMounts:
+        - name: volzookeeper
+          mountPath: /store
+      - name: init-zookeeper-logs
+        image: busybox
+        command: ['sh', '-c', 'mkdir -p /store/logs && chown 1000:1000 /store/logs']
+        volumeMounts:
+        - name: volzookeeper
+          mountPath: /store
+      - name: init-zookeeper-datalog
+        image: busybox
+        command: ['sh', '-c', 'mkdir -p /store/datalog && chown 1000:1000 /store/datalog']
+        volumeMounts:
+        - name: volzookeeper
+          mountPath: /store
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zookeeper-service
+spec:
+  ports:
+  - port: 32181
+    targetPort: 32181
+    nodePort: 32181
+    protocol: TCP
+  selector:
+    app: zookeeper-app
+  type: NodePort
+---
+apiVersion: apps/v1beta2
+kind: StatefulSet
+metadata:
+  name: solr-ss
+spec:
+  selector:
+    matchLabels:
+      app: solr-app
+  serviceName: "solr-service"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: solr-app
+    spec:
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: volsolr
+        persistentVolumeClaim:
+          claimName: task-solr-pv-claim
+      - name: volconfigset
+        persistentVolumeClaim:
+          claimName: task-solr-configset-pv-claim
+      containers:
+      - name: solr
+        image: solr:latest
+        volumeMounts:
+        - name: volsolr
+          mountPath: /store
+        - name: volconfigset
+          mountPath: /opt/solr/server/solr/configsets/
+        ports:
+        - name: solr-port
+          containerPort: 2181
+        env:
+          - name: SOLR_HOME
+            valueFrom:
+              configMapKeyRef:
+                name: solr-config
+                key: solrHome
+          - name: SOLR_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: solr-config
+                key: solrPort
+          - name: ZK_HOST
+            valueFrom:
+              configMapKeyRef:
+                name: solr-config
+                key: zkHost
+          - name: SOLR_HOST
+            valueFrom:
+              configMapKeyRef:
+                name: solr-config
+                key: solrHost
+          - name: SOLR_LOGS_DIR
+            valueFrom:
+              configMapKeyRef:
+                name: solr-config
+                key: solrLogsDir
+      initContainers:
+      - name: init-solr-data
+        image: busybox
+        command: ['sh', '-c', 'mkdir -p /store/data && chown 8983:8983 /store/data']
+        volumeMounts:
+        - name: volsolr
+          mountPath: /store
+      - name: init-solr-logs
+        image: busybox
+        command: ['sh', '-c', 'mkdir -p /store/logs && chown 8983:8983 /store/logs']
+        volumeMounts:
+        - name: volsolr
+          mountPath: /store
+      - name: init-solr-xml
+        image: solr:latest
+        command: ['sh', '-c', '[ ! -f /store/data/solr.xml ] && cp /opt/solr/server/solr/solr.xml /store/data/solr.xml || true']
+        volumeMounts:
+        - name: volsolr
+          mountPath: /store
+      - name: init-solr-configset
+        image: buggtb/sparkler-init:latest
+        volumeMounts:
+        - name: volconfigset
+          mountPath: /solr
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: solr-service
+spec:
+  ports:
+  - port: 32080
+    targetPort: 32080
+    nodePort: 32080
+    protocol: TCP
+  selector:
+    app: solr-app
+  type: NodePort
+

--- a/sparkler-deployment/helm/values.yaml
+++ b/sparkler-deployment/helm/values.yaml
@@ -33,14 +33,14 @@ zookeeperCluster:
 
 sparklerCluster:
   image:
-    name: buggtb/sparkler-standalone
+    name: uscdatascience/sparkler-standalone
     dockerTag: latest
   settings:
     replicaCount: 3
 
 sparklerInit:
   image:
-    name: buggtb/sparkler-init
+    name: uscdatascience/sparkler-init
     dockerTag: latest
 
 

--- a/sparkler-deployment/helm/values.yaml
+++ b/sparkler-deployment/helm/values.yaml
@@ -1,0 +1,54 @@
+# Default values for sparkler.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+solrCluster:
+  port: 32080
+  solr:
+    storage:
+      className: manual
+      capacity: 5Gi
+      path: /data/solr
+  configset:
+    storage:
+      className: manual
+      capacity: 1Gi
+      path: /data/solr-configset
+  image:
+    name: solr
+    dockerTag: latest
+  settings:
+    replicaCount: 1
+
+zookeeperCluster:
+  id: 1
+  port: 32181
+  storage:
+    className: manual
+    capacity: 5Gi
+    path: /data/zookeeper
+  image:
+    name: zookeeper
+    dockerTag: latest
+
+sparklerCluster:
+  image:
+    name: buggtb/sparkler-standalone
+    dockerTag: latest
+  settings:
+    replicaCount: 3
+
+sparklerInit:
+  image:
+    name: buggtb/sparkler-init
+    dockerTag: latest
+
+
+
+resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/sparkler-deployment/sparkler-init/Dockerfile
+++ b/sparkler-deployment/sparkler-init/Dockerfile
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Pull base image.
+
+# NOTE: always run docker build command from root of sparkler project
+# Build command:
+#    docker build -t sparkler-local -f sparkler-deployment/docker/Dockerfile .
+
+FROM ubuntu:bionic
+
+COPY ./conf/solr/crawldb /crawldb
+
+RUN ["mkdir","/solr"]
+ 
+CMD ["cp", "-r", "/crawldb", "/solr"]

--- a/sparkler-deployment/sparkler-k8s/deployment.yaml
+++ b/sparkler-deployment/sparkler-k8s/deployment.yaml
@@ -1,0 +1,302 @@
+---
+apiVersion: v1
+data:
+  solrHome: /store/data
+  solrHost: solr-service
+  solrLogsDir: /store/logs
+  solrPort: "32080"
+  zkHost: zookeeper-service:32181
+kind: ConfigMap
+metadata:
+  name: solr-config
+---
+apiVersion: v1
+data:
+  zooDataDir: /store/data
+  zooDataLogDir: /store/datalog
+  zooLogDir: /store/logs
+  zooMyId: "1"
+  zooPort: "32181"
+kind: ConfigMap
+metadata:
+  name: zookeeper-config
+---
+ apiVersion: extensions/v1beta1
+ kind: Deployment
+ metadata:
+   name: sparkler
+ spec:
+   replicas: 3
+   template:
+     metadata:
+       labels:
+         app: sparkler
+     spec:
+       containers:
+         - name: sparkler
+           image: buggtb/sparkler-standalone
+           command: ["tail", "-f", "/dev/null"]
+---
+ apiVersion: v1
+ kind: PersistentVolume
+ metadata:
+   name: zookeeper-volume
+ spec:
+   storageClassName: manual
+   accessModes:
+     - ReadWriteOnce
+   capacity:
+     storage: 5Gi
+   hostPath:
+     path: /data/zookeeper/
+---
+ apiVersion: v1
+ kind: PersistentVolume
+ metadata:
+   name: solr-volume
+ spec:
+   storageClassName: manual
+   accessModes:
+     - ReadWriteOnce
+   capacity:
+     storage: 5Gi
+   hostPath:
+     path: /data/solr
+---
+ apiVersion: v1
+ kind: PersistentVolume
+ metadata:
+   name: solr-configset-volume
+ spec:
+   storageClassName: manual
+   accessModes:
+     - ReadWriteOnce
+   capacity:
+     storage: 1Gi
+   hostPath:
+     path: /data/solr-configset
+---
+ kind: PersistentVolumeClaim
+ apiVersion: v1
+ metadata:
+   name: task-solr-configset-pv-claim
+ spec:
+   storageClassName: manual
+   accessModes:
+     - ReadWriteOnce
+   resources:
+     requests:
+       storage: 1Gi
+---
+ kind: PersistentVolumeClaim
+ apiVersion: v1
+ metadata:
+   name: task-zookeeper-pv-claim
+ spec:
+   storageClassName: manual
+   accessModes:
+     - ReadWriteOnce
+   resources:
+     requests:
+       storage: 1Gi
+---
+ kind: PersistentVolumeClaim
+ apiVersion: v1
+ metadata:
+   name: task-solr-pv-claim
+ spec:
+   storageClassName: manual
+   accessModes:
+     - ReadWriteOnce
+   resources:
+     requests:
+       storage: 1Gi
+---
+apiVersion: apps/v1beta2
+kind: StatefulSet
+metadata:
+  name: zookeeper-ss
+spec:
+  selector:
+    matchLabels:
+      app: zookeeper-app # has to match .spec.template.metadata.labels
+  serviceName: "zookeeper-service"
+  replicas: 1 # by default is 1
+  template:
+    metadata:
+      labels:
+        app: zookeeper-app # has to match .spec.selector.matchLabels
+    spec:
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: volzookeeper
+        persistentVolumeClaim:
+          claimName: task-zookeeper-pv-claim
+      containers:
+      - name: zookeeper
+        image: zookeeper:latest
+        volumeMounts:
+        - name: volzookeeper
+          mountPath: /store
+        ports:
+        - name: zookeeper-port
+          containerPort: 2181
+        env:
+          - name: ZOO_MY_ID
+            valueFrom:
+              configMapKeyRef:
+                name: zookeeper-config
+                key: zooMyId
+          - name: ZOO_LOG_DIR
+            valueFrom:
+              configMapKeyRef:
+                name: zookeeper-config
+                key: zooLogDir
+          - name: ZOO_DATA_DIR
+            valueFrom:
+              configMapKeyRef:
+                name: zookeeper-config
+                key: zooDataDir
+          - name: ZOO_DATA_LOG_DIR
+            valueFrom:
+              configMapKeyRef:
+                name: zookeeper-config
+                key: zooDataLogDir
+          - name: ZOO_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: zookeeper-config
+                key: zooPort
+      initContainers:
+      - name: init-zookeeper-data
+        image: busybox
+        command: ['sh', '-c', 'mkdir -p /store/data && chown 1000:1000 /store/data']
+        volumeMounts:
+        - name: volzookeeper
+          mountPath: /store
+      - name: init-zookeeper-logs
+        image: busybox
+        command: ['sh', '-c', 'mkdir -p /store/logs && chown 1000:1000 /store/logs']
+        volumeMounts:
+        - name: volzookeeper
+          mountPath: /store
+      - name: init-zookeeper-datalog
+        image: busybox
+        command: ['sh', '-c', 'mkdir -p /store/datalog && chown 1000:1000 /store/datalog']
+        volumeMounts:
+        - name: volzookeeper
+          mountPath: /store
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zookeeper-service
+spec:
+  ports:
+  - port: 32181
+    targetPort: 32181
+    nodePort: 32181
+    protocol: TCP
+  selector:
+    app: zookeeper-app
+  type: NodePort
+---
+apiVersion: apps/v1beta2
+kind: StatefulSet
+metadata:
+  name: solr-ss
+spec:
+  selector:
+    matchLabels:
+      app: solr-app # has to match .spec.template.metadata.labels
+  serviceName: "solr-service"
+  replicas: 1 # by default is 1
+  template:
+    metadata:
+      labels:
+        app: solr-app # has to match .spec.selector.matchLabels
+    spec:
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: volsolr
+        persistentVolumeClaim:
+          claimName: task-solr-pv-claim
+      - name: volconfigset
+        persistentVolumeClaim:
+          claimName: task-solr-configset-pv-claim
+      containers:
+      - name: solr
+        image: solr:latest
+        volumeMounts:
+        - name: volsolr
+          mountPath: /store
+        - name: volconfigset
+          mountPath: /opt/solr/server/solr/configsets/
+        ports:
+        - name: solr-port
+          containerPort: 2181
+        env:
+          - name: SOLR_HOME
+            valueFrom:
+              configMapKeyRef:
+                name: solr-config
+                key: solrHome
+          - name: SOLR_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: solr-config
+                key: solrPort
+          - name: ZK_HOST
+            valueFrom:
+              configMapKeyRef:
+                name: solr-config
+                key: zkHost
+          - name: SOLR_HOST
+            valueFrom:
+              configMapKeyRef:
+                name: solr-config
+                key: solrHost
+          - name: SOLR_LOGS_DIR
+            valueFrom:
+              configMapKeyRef:
+                name: solr-config
+                key: solrLogsDir
+      initContainers:
+      - name: init-solr-data
+        image: busybox
+        command: ['sh', '-c', 'mkdir -p /store/data && chown 8983:8983 /store/data']
+        volumeMounts:
+        - name: volsolr
+          mountPath: /store
+      - name: init-solr-logs
+        image: busybox
+        command: ['sh', '-c', 'mkdir -p /store/logs && chown 8983:8983 /store/logs']
+        volumeMounts:
+        - name: volsolr
+          mountPath: /store
+      - name: init-solr-xml
+        image: solr:latest
+        command: ['sh', '-c', '[ ! -f /store/data/solr.xml ] && cp /opt/solr/server/solr/solr.xml /store/data/solr.xml || true']
+        volumeMounts:
+        - name: volsolr
+          mountPath: /store
+      - name: init-solr-configset
+        image: buggtb/sparkler-init
+        volumeMounts:
+        - name: volconfigset
+          mountPath: /solr
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: solr-service
+spec:
+  ports:
+  - port: 32080
+    targetPort: 32080
+    nodePort: 32080
+    protocol: TCP
+  selector:
+    app: solr-app
+  type: NodePort
+


### PR DESCRIPTION
This PR contains:

* A travis update to push the sparkler container on each build
* A skinny Docker image with just sparkler in it
* An init docker image to deploy the solr configs in K8S
* A basic Kubernetes deployment template
* A Helm chart for helm users.
