### PR TITLE
Always use the latest docker image

### DIFF
--- a/bin/dockler.sh
+++ b/bin/dockler.sh
@@ -28,7 +28,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DIR="$DIR/.."
 
 docker_tag="sparkler-local"
-remote_image="uscdatascience/sparkler:0.1"
+remote_image="uscdatascience/sparkler:latest"
 solr_port=8983
 solr_url="http://localhost:$solr_port/solr"
 spark_ui_port=4041


### PR DESCRIPTION
## What changes were proposed in this pull request?

Always using the latest docker image when starting from `dockler.sh`

**Is this related to an already existing issue on sparkler?**  
No

**Will it close an existing issue?**  
No


### How was this patch tested?

Ran `dockler.sh` and it pulled and started the latest image.


Please review
https://github.com/USCDataScience/sparkler/blob/master/.github/CONTRIBUTING.md before opening a pull request.
