### PR TITLE
Updates kubernetes deployment config and containers for v1.14 and v1.15

### DIFF
--- a/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/Crawler.scala
+++ b/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/Crawler.scala
@@ -135,7 +135,7 @@ class Crawler extends CliTool {
     init()
     // 0 is infinite crawl
     if (iterations <= 0){
-      LOG.info("Going tp crawl until the end of all URLs. This is gonna take long time")
+      LOG.info("Going to crawl until the end of all URLs. This is gonna take long time")
       iterations = Int.MaxValue
     }
     val solrc = this.job.newCrawlDbSolrClient()

--- a/sparkler-deployment/docker-k8s/Dockerfile
+++ b/sparkler-deployment/docker-k8s/Dockerfile
@@ -26,7 +26,7 @@ FROM openjdk:8
 RUN groupadd --gid 1000 sparkler && \
    useradd -M --uid 1000 --gid 1000 --home /home/sparkler sparkler
 
-RUN apt-get update && apt-get install -y -qq --fix-missing openjfx nano
+RUN apt-get update && apt-get install -y -qq --fix-missing software-properties-common openjfx nano
 
 
 # Define working directory.

--- a/sparkler-deployment/sparkler-init/Dockerfile
+++ b/sparkler-deployment/sparkler-init/Dockerfile
@@ -23,8 +23,13 @@
 
 FROM ubuntu:bionic
 
-COPY ./conf/solr/crawldb /crawldb
+COPY ./conf/solr /solr
 
-RUN ["mkdir","/solr"]
- 
-CMD ["cp", "-r", "/crawldb", "/solr"]
+RUN groupadd --gid 8983 solr && \
+    useradd -M --uid 8983 --gid 8983 solr
+
+USER root
+
+RUN ["chown", "-R", "8983:8983", "/solr/"]
+
+USER solr

--- a/sparkler-deployment/sparkler-k8s/deployment.yaml
+++ b/sparkler-deployment/sparkler-k8s/deployment.yaml
@@ -1,207 +1,61 @@
----
 apiVersion: v1
 data:
   solrHome: /store/data
   solrHost: solr-service
   solrLogsDir: /store/logs
   solrPort: "32080"
-  zkHost: zookeeper-service:32181
 kind: ConfigMap
 metadata:
   name: solr-config
 ---
-apiVersion: v1
-data:
-  zooDataDir: /store/data
-  zooDataLogDir: /store/datalog
-  zooLogDir: /store/logs
-  zooMyId: "1"
-  zooPort: "32181"
-kind: ConfigMap
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: zookeeper-config
----
- apiVersion: extensions/v1beta1
- kind: Deployment
- metadata:
-   name: sparkler
- spec:
-   replicas: 3
-   template:
-     metadata:
-       labels:
-         app: sparkler
-     spec:
-       containers:
-         - name: sparkler
-           image: buggtb/sparkler-standalone
-           command: ["tail", "-f", "/dev/null"]
----
- apiVersion: v1
- kind: PersistentVolume
- metadata:
-   name: zookeeper-volume
- spec:
-   storageClassName: manual
-   accessModes:
-     - ReadWriteOnce
-   capacity:
-     storage: 5Gi
-   hostPath:
-     path: /data/zookeeper/
----
- apiVersion: v1
- kind: PersistentVolume
- metadata:
-   name: solr-volume
- spec:
-   storageClassName: manual
-   accessModes:
-     - ReadWriteOnce
-   capacity:
-     storage: 5Gi
-   hostPath:
-     path: /data/solr
----
- apiVersion: v1
- kind: PersistentVolume
- metadata:
-   name: solr-configset-volume
- spec:
-   storageClassName: manual
-   accessModes:
-     - ReadWriteOnce
-   capacity:
-     storage: 1Gi
-   hostPath:
-     path: /data/solr-configset
----
- kind: PersistentVolumeClaim
- apiVersion: v1
- metadata:
-   name: task-solr-configset-pv-claim
- spec:
-   storageClassName: manual
-   accessModes:
-     - ReadWriteOnce
-   resources:
-     requests:
-       storage: 1Gi
----
- kind: PersistentVolumeClaim
- apiVersion: v1
- metadata:
-   name: task-zookeeper-pv-claim
- spec:
-   storageClassName: manual
-   accessModes:
-     - ReadWriteOnce
-   resources:
-     requests:
-       storage: 1Gi
----
- kind: PersistentVolumeClaim
- apiVersion: v1
- metadata:
-   name: task-solr-pv-claim
- spec:
-   storageClassName: manual
-   accessModes:
-     - ReadWriteOnce
-   resources:
-     requests:
-       storage: 1Gi
----
-apiVersion: apps/v1beta2
-kind: StatefulSet
-metadata:
-  name: zookeeper-ss
+  name: sparkler
 spec:
+  replicas: 3
   selector:
     matchLabels:
-      app: zookeeper-app # has to match .spec.template.metadata.labels
-  serviceName: "zookeeper-service"
-  replicas: 1 # by default is 1
+      app: sparkler
   template:
     metadata:
       labels:
-        app: zookeeper-app # has to match .spec.selector.matchLabels
+        app: sparkler
     spec:
-      terminationGracePeriodSeconds: 10
-      volumes:
-      - name: volzookeeper
-        persistentVolumeClaim:
-          claimName: task-zookeeper-pv-claim
       containers:
-      - name: zookeeper
-        image: zookeeper:latest
-        volumeMounts:
-        - name: volzookeeper
-          mountPath: /store
-        ports:
-        - name: zookeeper-port
-          containerPort: 2181
-        env:
-          - name: ZOO_MY_ID
-            valueFrom:
-              configMapKeyRef:
-                name: zookeeper-config
-                key: zooMyId
-          - name: ZOO_LOG_DIR
-            valueFrom:
-              configMapKeyRef:
-                name: zookeeper-config
-                key: zooLogDir
-          - name: ZOO_DATA_DIR
-            valueFrom:
-              configMapKeyRef:
-                name: zookeeper-config
-                key: zooDataDir
-          - name: ZOO_DATA_LOG_DIR
-            valueFrom:
-              configMapKeyRef:
-                name: zookeeper-config
-                key: zooDataLogDir
-          - name: ZOO_PORT
-            valueFrom:
-              configMapKeyRef:
-                name: zookeeper-config
-                key: zooPort
-      initContainers:
-      - name: init-zookeeper-data
-        image: busybox
-        command: ['sh', '-c', 'mkdir -p /store/data && chown 1000:1000 /store/data']
-        volumeMounts:
-        - name: volzookeeper
-          mountPath: /store
-      - name: init-zookeeper-logs
-        image: busybox
-        command: ['sh', '-c', 'mkdir -p /store/logs && chown 1000:1000 /store/logs']
-        volumeMounts:
-        - name: volzookeeper
-          mountPath: /store
-      - name: init-zookeeper-datalog
-        image: busybox
-        command: ['sh', '-c', 'mkdir -p /store/datalog && chown 1000:1000 /store/datalog']
-        volumeMounts:
-        - name: volzookeeper
-          mountPath: /store
+        - name: sparkler
+          image: brake4stones/sparkler-standalone
+          command: ["/bin/bash", "-c"]
+          args:
+          - sed -i 's/localhost:8983/solr-service:32080/g' /data/sparkler/conf/sparkler-default.yaml;
+            tail -f /dev/null;
 ---
 apiVersion: v1
-kind: Service
+kind: PersistentVolume
 metadata:
-  name: zookeeper-service
+  name: solr-volume
 spec:
-  ports:
-  - port: 32181
-    targetPort: 32181
-    nodePort: 32181
-    protocol: TCP
-  selector:
-    app: zookeeper-app
-  type: NodePort
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 5Gi
+  hostPath:
+    path: /data/solr
 ---
-apiVersion: apps/v1beta2
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: task-solr-pv-claim
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: solr-ss
@@ -218,73 +72,67 @@ spec:
     spec:
       terminationGracePeriodSeconds: 10
       volumes:
-      - name: volsolr
-        persistentVolumeClaim:
-          claimName: task-solr-pv-claim
-      - name: volconfigset
-        persistentVolumeClaim:
-          claimName: task-solr-configset-pv-claim
+        - name: volsolr
+          persistentVolumeClaim:
+            claimName: task-solr-pv-claim
       containers:
-      - name: solr
-        image: solr:latest
-        volumeMounts:
-        - name: volsolr
-          mountPath: /store
-        - name: volconfigset
-          mountPath: /opt/solr/server/solr/configsets/
-        ports:
-        - name: solr-port
-          containerPort: 2181
-        env:
-          - name: SOLR_HOME
-            valueFrom:
-              configMapKeyRef:
-                name: solr-config
-                key: solrHome
-          - name: SOLR_PORT
-            valueFrom:
-              configMapKeyRef:
-                name: solr-config
-                key: solrPort
-          - name: ZK_HOST
-            valueFrom:
-              configMapKeyRef:
-                name: solr-config
-                key: zkHost
-          - name: SOLR_HOST
-            valueFrom:
-              configMapKeyRef:
-                name: solr-config
-                key: solrHost
-          - name: SOLR_LOGS_DIR
-            valueFrom:
-              configMapKeyRef:
-                name: solr-config
-                key: solrLogsDir
+        - name: solr
+          image: solr:latest
+          volumeMounts:
+            - name: volsolr
+              mountPath: /store
+          ports:
+          - name: solr-port
+            containerPort: 2181
+          env:
+            - name: SOLR_HOME
+              valueFrom:
+                configMapKeyRef:
+                  name: solr-config
+                  key: solrHome
+            - name: SOLR_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: solr-config
+                  key: solrPort
+            - name: SOLR_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: solr-config
+                  key: solrHost
+            - name: SOLR_LOGS_DIR
+              valueFrom:
+                configMapKeyRef:
+                  name: solr-config
+                  key: solrLogsDir
       initContainers:
-      - name: init-solr-data
-        image: busybox
-        command: ['sh', '-c', 'mkdir -p /store/data && chown 8983:8983 /store/data']
-        volumeMounts:
-        - name: volsolr
-          mountPath: /store
-      - name: init-solr-logs
-        image: busybox
-        command: ['sh', '-c', 'mkdir -p /store/logs && chown 8983:8983 /store/logs']
-        volumeMounts:
-        - name: volsolr
-          mountPath: /store
-      - name: init-solr-xml
-        image: solr:latest
-        command: ['sh', '-c', '[ ! -f /store/data/solr.xml ] && cp /opt/solr/server/solr/solr.xml /store/data/solr.xml || true']
-        volumeMounts:
-        - name: volsolr
-          mountPath: /store
-      - name: init-solr-configset
-        image: buggtb/sparkler-init
-        volumeMounts:
-        - name: volconfigset
-          mountPath: /solr
+        - name: init-solr-data
+          image: busybox
+          command: ['sh', '-c']
+          args:
+            - mkdir -p /store/data && chown 8983:8983 /store/data;
+              mkdir -p /store/logs && chown 8983:8983 /store/logs;
+          volumeMounts:
+            - name: volsolr
+              mountPath: /store
+        - name: init-solr-xml
+          image: solr:latest
+          command: ['sh', '-c']
+          args:
+            - cp /opt/solr/server/solr/solr.xml /store/data/solr.xml;
+              cp /opt/solr/server/solr/zoo.cfg /store/data/zoo.cfg;
+          volumeMounts:
+            - name: volsolr
+              mountPath: /store
+        - name: init-solr-configset
+          image: brake4stones/crawldb-init
+          command: ['bash', '-c']
+          args:
+            - chown -R 8983:8983 /solr/;
+              cp -r /solr/crawldb /store/data/;
+          volumeMounts:
+            - name: volsolr
+              mountPath: /store
 ---
 apiVersion: v1
 kind: Service
@@ -292,11 +140,10 @@ metadata:
   name: solr-service
 spec:
   ports:
-  - port: 32080
-    targetPort: 32080
-    nodePort: 32080
-    protocol: TCP
+    - port: 32080
+      targetPort: 32080
+      nodePort: 32080
+      protocol: TCP
   selector:
     app: solr-app
   type: NodePort
-


### PR DESCRIPTION
## What changes were proposed in this pull request?

The kubernetes deployment config file was updated to work with kubernetes versions 1.14 and 1.15 to allow for deployment to AWS EKS. All API versions declared in the config were switched to stable releases, as the features that were previously used from the betas were since incorporated.

Zookeeper was removed from the deployment file due to unaccounted for problems that arose from its incorporation (solr would not run and would not give a meaningful error). However, all sparkler pods appear to work fine with a single solr instance.

The `standalone-sparkler` docker image was rebuilt from the current state of the repository and the `sparkler-init` docker image was slightly modified and rebuilt to deal with permissions issues that prevented the crawldb core to be created in solr.

A minor misspelling was also corrected in Crawler.scala.

**Is this related to an already existing issue on sparkler?**  
Related to #166 and #167. 

**Will it close an existing issue?**  
Closes #167, #166. 

### How was this patch tested?

The deployment was manually tested on minikube running both kubernetes versions 1.14 and 1.15 and on a 3-node AWS EKS cluster.

Please review
https://github.com/USCDataScience/sparkler/blob/master/.github/CONTRIBUTING.md before opening a pull request.
