### PR TITLE
Modified Readme for crawling seed-urls.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ bash dockler.sh
 
 * Note: You can use Vim and Nano editors also or use: echo -e "http://example1.com\nhttp://example2.com" >> seedfile.txt command.
 
-3. Inject seed urls using the following command, 
-/sparkler/bin/sparkler.sh inject -id 1 -sf seed-urls.txt
+3. Inject seed urls using the following command, (assuming you are in sparkler/bin directory) 
+$bash sparkler.sh inject -id 1 -sf seed-urls.txt
 4. Start the crawl job.
 ```
 To crawl until the end of all new URLS, use `-i -1`, Example: `/data/sparkler/bin/sparkler.sh crawl -id 1 -i -1`


### PR DESCRIPTION
## What changes were proposed in this pull request?
Only the Readme was changed. When injecting the crawler from a list of websites on seed-urls.txt 'bash' command has to be used on mac device terminal due to differences in bash versions.
(Please fill in changes proposed in this fix)

**Is this related to an already existing issue on sparkler?**  
 If so, mention that issue by referencing its number here.

**Will it close an existing issue?**  
Say 'Closes #IssueNum' here.


### How was this patch tested?

We are particularly interested in unit tests, integration tests, manual tests you did to ensure that the patch works as expected, so briefly describe them.


Please review
https://github.com/USCDataScience/sparkler/blob/master/.github/CONTRIBUTING.md before opening a pull request.
