### PR TITLE
Changes so sparkler can be launched inside of a Databricks cluster

### DIFF
--- a/sparkler-core/sparkler-api/src/main/java/edu/usc/irds/sparkler/Constants.java
+++ b/sparkler-core/sparkler-api/src/main/java/edu/usc/irds/sparkler/Constants.java
@@ -54,6 +54,10 @@ public interface Constants {
         @ConfigKey
         String KAFKA_TOPIC = "kafka.topic";
 
+        // Databricks Properties
+        @ConfigKey
+        String DATABRICKS_ENABLE = "databricks.enable";
+
         // HTTP Properties
         // Database Properties
 

--- a/sparkler-core/sparkler-app/pom.xml
+++ b/sparkler-core/sparkler-app/pom.xml
@@ -56,9 +56,17 @@
 
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_${version.scala.epoch}</artifactId>
+	    <artifactId>spark-core_${version.scala.epoch}</artifactId>
             <version>${spark.version}</version>
         </dependency>
+
+	<!-- https://mvnrepository.com/artifact/org.apache.spark/spark-sql -->
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_${version.scala.epoch}</artifactId>
+            <version>${spark.version}</version>
+        </dependency>
+
 
         <dependency>
             <groupId>org.apache.nutch</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changes so Sparkler can be optionally configured to run in a Databricks spark environment

**Is this related to an already existing issue on sparkler?**  
#204

**Will it close an existing issue?**  
#204


### How was this patch tested?

The resulting fat jar zipped up with the conf and plugin directories and copied up to the databricks file system (dbfs).   Then scripted to be pulled onto Master node of a cluster, unzipped and executed.  Sample crawls and scraps where performed that persisted results in a standalone EC2 Solr server.   Then pulled from Solr via rest api.

Please review
https://github.com/USCDataScience/sparkler/blob/master/.github/CONTRIBUTING.md before opening a pull request.
