### PR TITLE
URL Injector/Config override and bug fixes

### DIFF
--- a/sparkler-core/conf/regex-urlfilter.txt
+++ b/sparkler-core/conf/regex-urlfilter.txt
@@ -27,7 +27,7 @@
 
 # Default: skip image and other suffixes which produces large content
 # for a more extensive coverage use the urlfilter-suffix plugin
--\.(gif|GIF|jpg|JPG|png|PNG|ico|ICO|css|CSS|sit|SIT|eps|EPS|wmf|WMF|zip|ZIP|ppt|PPT|mpg|MPG|xls|XLS|gz|GZ|rpm|RPM|tgz|TGZ|mov|MOV|exe|EXE|jpeg|JPEG|bmp|BMP|js|JS|svg|SVG|mp3|MP3|mp4|MP4)$
+-\.(gif|GIF|jpg|JPG|png|PNG|ico|ICO|css|CSS|sit|SIT|eps|EPS|wmf|WMF|zip|ZIP|ppt|PPT|mpg|MPG|xls|XLS|gz|GZ|rpm|RPM|tgz|TGZ|mov|MOV|exe|EXE|jpeg|JPEG|bmp|BMP|js|JS|svg|SVG|mp3|MP3|mp4|MP4|pdf|PDF)$
 
 # skip URLs containing certain characters as probable queries, etc.
 -[?*!@=]

--- a/sparkler-core/conf/regex-urlfilter.txt
+++ b/sparkler-core/conf/regex-urlfilter.txt
@@ -27,7 +27,7 @@
 
 # Default: skip image and other suffixes which produces large content
 # for a more extensive coverage use the urlfilter-suffix plugin
--\.(gif|GIF|jpg|JPG|png|PNG|ico|ICO|css|CSS|sit|SIT|eps|EPS|wmf|WMF|zip|ZIP|ppt|PPT|mpg|MPG|xls|XLS|gz|GZ|rpm|RPM|tgz|TGZ|mov|MOV|exe|EXE|jpeg|JPEG|bmp|BMP|js|JS|svg|SVG|mp3|MP3|mp4|MP4|pdf|PDF)$
+-\.(gif|GIF|jpg|JPG|png|PNG|ico|ICO|css|CSS|sit|SIT|eps|EPS|wmf|WMF|zip|ZIP|ppt|PPT|mpg|MPG|xls|XLS|gz|GZ|rpm|RPM|tgz|TGZ|mov|MOV|exe|EXE|jpeg|JPEG|bmp|BMP|js|JS|svg|SVG|mp3|MP3|mp4|MP4)$
 
 # skip URLs containing certain characters as probable queries, etc.
 -[?*!@=]

--- a/sparkler-core/conf/solr/crawldb/conf/managed-schema
+++ b/sparkler-core/conf/solr/crawldb/conf/managed-schema
@@ -151,7 +151,8 @@
    <field name="seed" type="string" indexed="true" stored="true" multiValued="false" docValues="true" />
    <field name="modified_time" type="date" indexed="true" stored="true" multiValued="false" default="NOW" />
    <field name="retries_since_fetch" type="int" indexed="true" stored="true" default="-1" multiValued="false" docValues="true" />
-
+   <field name="metadata" type="string" indexed="true" stored="true" multiValued="false" docValues="true"/>
+   <field name="http_method" type="string" indexed="true" stored="true" multiValued="false" docValues="true"/>
    <field name="response_time" type="long" indexed="true" stored="true" default="0" multiValued="false" docValues="true" />
 
   <!-- Admin -->

--- a/sparkler-core/conf/sparkler-default.yaml
+++ b/sparkler-core/conf/sparkler-default.yaml
@@ -100,6 +100,7 @@ plugins.active:
 
     - urlfilter-regex
     - urlfilter-samehost
+    - url-injector
 #    - scorer-dd-svn
 #    - fetcher-jbrowser
 #    - fetcher-htmlunit
@@ -131,6 +132,10 @@ plugins:
     #What type of element, class, name, id
     chrome.wait.type: "class"
     chrome.dns: "http://localhost:3000/webdriver"
+    chrome.selenium.enabled: "true"
+    chrome.selenium.script.click: "id:txtName"
+    chrome.selenium.script.keys: "COR"
+    chrome.selenium.script.click: "id:btnSearch" 
 ##################### Custom properties for MEMEX ###########################################
   memex.webpage.mimetype: "text/html"
 

--- a/sparkler-core/conf/sparkler-default.yaml
+++ b/sparkler-core/conf/sparkler-default.yaml
@@ -137,12 +137,13 @@ plugins:
     #chrome.selenium.script.keys: "COR"
     #chrome.selenium.script.click: "id:btnSearch" 
   url.injector:
-    mode: selenium
+    #mode: selenium
     #mode: replace
+    mode: json
     values:
-      - COR
-      - VEN
-      - SOM
+      - "\"COR\""
+      - "\"VEN\""
+      - "\"SOM\""
     selenium:
       1: 
         operation: click
@@ -153,6 +154,7 @@ plugins:
       3:
         operation: click
         value: "id:btnSearch" 
+    json: "{ \"name\":\"John\", \"age\":${token}, \"car\":null }"
 ##################### Custom properties for MEMEX ###########################################
   memex.webpage.mimetype: "text/html"
 

--- a/sparkler-core/conf/sparkler-default.yaml
+++ b/sparkler-core/conf/sparkler-default.yaml
@@ -104,7 +104,7 @@ plugins.active:
 #    - scorer-dd-svn
 #    - fetcher-jbrowser
 #    - fetcher-htmlunit
-#    - fetcher-chrome
+    - fetcher-chrome
 
 # All Plugins are listed under this tree
 plugins:
@@ -137,13 +137,18 @@ plugins:
     #chrome.selenium.script.keys: "COR"
     #chrome.selenium.script.click: "id:btnSearch" 
   url.injector:
-    #mode: selenium
+    #mode: selenium # currently only compatible with the fetcher-chrome plugin
     #mode: replace
-    mode: json
+    #mode: json
+    mode: form
+    #values: #escaped for json
+    #  - "\"COR\""
+    #  - "\"VEN\""
+    #  - "\"SOM\""
     values:
-      - "\"COR\""
-      - "\"VEN\""
-      - "\"SOM\""
+      - COR
+      - VEN
+      - SOC
     selenium:
       1: 
         operation: click
@@ -155,6 +160,14 @@ plugins:
         operation: click
         value: "id:btnSearch" 
     json: "{ \"name\":\"John\", \"age\":${token}, \"car\":null }"
+    form:
+      hdnField: "submit"
+      txtRequired: ""
+      radSearchBy: "drugname"
+      txtName: "${token}"
+      selTC: ""
+      selProgram: "MA"
+      txtDateOfService: "12/01/2020"
 ##################### Custom properties for MEMEX ###########################################
   memex.webpage.mimetype: "text/html"
 

--- a/sparkler-core/conf/sparkler-default.yaml
+++ b/sparkler-core/conf/sparkler-default.yaml
@@ -80,6 +80,7 @@ fetcher.headers:
   User-Agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Sparkler/${project.version}"
   Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
   Accept-Language: "en-US,en"
+  Referer: http://minnesota.magellanmedicaid.com/drug_search.asp
 
 # Rotating agents file.
 # File should contain a list of agents which will be used to override the default agent string
@@ -100,11 +101,11 @@ plugins.active:
 
     - urlfilter-regex
     - urlfilter-samehost
-#    - url-injector
+    - url-injector
 #    - scorer-dd-svn
 #    - fetcher-jbrowser
 #    - fetcher-htmlunit
-    - fetcher-chrome
+#    - fetcher-chrome
 
 # All Plugins are listed under this tree
 plugins:

--- a/sparkler-core/conf/sparkler-default.yaml
+++ b/sparkler-core/conf/sparkler-default.yaml
@@ -80,7 +80,7 @@ fetcher.headers:
   User-Agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Sparkler/${project.version}"
   Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
   Accept-Language: "en-US,en"
-  Referer: http://minnesota.magellanmedicaid.com/drug_search.asp
+  #Referer: http://minnesota.magellanmedicaid.com/drug_search.asp
 
 # Rotating agents file.
 # File should contain a list of agents which will be used to override the default agent string
@@ -101,7 +101,7 @@ plugins.active:
 
     - urlfilter-regex
     - urlfilter-samehost
-#    - url-injector
+    - url-injector
 #    - scorer-dd-svn
 #    - fetcher-jbrowser
 #    - fetcher-htmlunit
@@ -139,28 +139,28 @@ plugins:
     #chrome.selenium.script.click: "id:btnSearch" 
     chrome.proxy.address: 172.17.146.238:9998
   url.injector:
-    #mode: selenium # currently only compatible with the fetcher-chrome plugin
+    mode: selenium # currently only compatible with the fetcher-chrome plugin
     #mode: replace
     #mode: json
-    mode: form
+    #mode: form
     #values: #escaped for json
     #  - "\"COR\""
     #  - "\"VEN\""
     #  - "\"SOM\""
     values:
-      - COR
-      - VEN
-      - SOC
+      - Acitretin
+      - Adempas
+      - Actiq
     selenium:
-      1: 
+      1:
         operation: click
-        value: "id:txtName"
+        value: id:ctl00_ContentPlaceHolder1_rcbDrugName_Arrow
       2:
         operation: keys
-        value: "${token}"
+        value: "id:ctl00_ContentPlaceHolder1_rcbDrugName_Input:${token}"
       3:
         operation: click
-        value: "id:btnSearch" 
+        value: "id:ctl00_ContentPlaceHolder1_DrugSearch" 
     json: "{ \"name\":\"John\", \"age\":${token}, \"car\":null }"
     form:
       hdnField: "submit"

--- a/sparkler-core/conf/sparkler-default.yaml
+++ b/sparkler-core/conf/sparkler-default.yaml
@@ -100,7 +100,7 @@ plugins.active:
 
     - urlfilter-regex
     - urlfilter-samehost
-    - url-injector
+#    - url-injector
 #    - scorer-dd-svn
 #    - fetcher-jbrowser
 #    - fetcher-htmlunit
@@ -132,10 +132,10 @@ plugins:
     #What type of element, class, name, id
     chrome.wait.type: "class"
     chrome.dns: "http://localhost:3000/webdriver"
-    chrome.selenium.enabled: "true"
-    chrome.selenium.script.click: "id:txtName"
-    chrome.selenium.script.keys: "COR"
-    chrome.selenium.script.click: "id:btnSearch" 
+    #chrome.selenium.enabled: "true"
+    #chrome.selenium.script.click: "id:txtName"
+    #chrome.selenium.script.keys: "COR"
+    #chrome.selenium.script.click: "id:btnSearch" 
   url.injector:
     mode: selenium
     #mode: replace

--- a/sparkler-core/conf/sparkler-default.yaml
+++ b/sparkler-core/conf/sparkler-default.yaml
@@ -136,6 +136,23 @@ plugins:
     chrome.selenium.script.click: "id:txtName"
     chrome.selenium.script.keys: "COR"
     chrome.selenium.script.click: "id:btnSearch" 
+  url.injector:
+    mode: selenium
+    #mode: replace
+    values:
+      - COR
+      - VEN
+      - SOM
+    selenium:
+      1: 
+        operation: click
+        value: "id:txtName"
+      2:
+        operation: keys
+        value: "${token}"
+      3:
+        operation: click
+        value: "id:btnSearch" 
 ##################### Custom properties for MEMEX ###########################################
   memex.webpage.mimetype: "text/html"
 

--- a/sparkler-core/conf/sparkler-default.yaml
+++ b/sparkler-core/conf/sparkler-default.yaml
@@ -101,11 +101,11 @@ plugins.active:
 
     - urlfilter-regex
     - urlfilter-samehost
-    - url-injector
+#    - url-injector
 #    - scorer-dd-svn
 #    - fetcher-jbrowser
 #    - fetcher-htmlunit
-#    - fetcher-chrome
+    - fetcher-chrome
 
 # All Plugins are listed under this tree
 plugins:
@@ -137,6 +137,7 @@ plugins:
     #chrome.selenium.script.click: "id:txtName"
     #chrome.selenium.script.keys: "COR"
     #chrome.selenium.script.click: "id:btnSearch" 
+    chrome.proxy.address: 172.17.146.238:9998
   url.injector:
     #mode: selenium # currently only compatible with the fetcher-chrome plugin
     #mode: replace

--- a/sparkler-core/pom.xml
+++ b/sparkler-core/pom.xml
@@ -71,6 +71,10 @@
     </modules>
     <repositories>
         <repository>
+          <id>gitlab-maven</id>
+          <url>https://gitlab.com/api/v4/projects/23300400/packages/maven</url>
+        </repository>
+        <repository>
             <id>central</id>
             <name>Maven Central</name>
             <layout>default</layout>

--- a/sparkler-core/pom.xml
+++ b/sparkler-core/pom.xml
@@ -22,7 +22,7 @@
 
     <artifactId>sparkler-parent</artifactId>
     <groupId>edu.usc.irds.sparkler</groupId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.2.2-SNAPSHOT</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <properties>

--- a/sparkler-core/pom.xml
+++ b/sparkler-core/pom.xml
@@ -73,6 +73,9 @@
         <repository>
           <id>gitlab-maven</id>
           <url>https://gitlab.com/api/v4/projects/23300400/packages/maven</url>
+          <snapshots>
+             <enabled>true</enabled>
+          </snapshots>
         </repository>
         <repository>
             <id>central</id>

--- a/sparkler-core/sparkler-api/pom.xml
+++ b/sparkler-core/sparkler-api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>sparkler-parent</artifactId>
         <groupId>edu.usc.irds.sparkler</groupId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.2.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sparkler-core/sparkler-api/pom.xml
+++ b/sparkler-core/sparkler-api/pom.xml
@@ -108,5 +108,11 @@
             <artifactId>pf4j</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.6</version>
+        </dependency>
+
     </dependencies>
 </project>

--- a/sparkler-core/sparkler-api/src/main/java/edu/usc/irds/sparkler/Config.java
+++ b/sparkler-core/sparkler-api/src/main/java/edu/usc/irds/sparkler/Config.java
@@ -1,0 +1,7 @@
+package edu.usc.irds.sparkler;
+
+import java.util.List;
+
+public interface Config extends ExtensionPoint {
+    public List<String> processConfig();    
+}

--- a/sparkler-core/sparkler-api/src/main/java/edu/usc/irds/sparkler/Config.java
+++ b/sparkler-core/sparkler-api/src/main/java/edu/usc/irds/sparkler/Config.java
@@ -1,7 +1,7 @@
 package edu.usc.irds.sparkler;
 
-import java.util.List;
+import java.util.Collection;
 
 public interface Config extends ExtensionPoint {
-    public List<String> processConfig();    
+    public Collection<UrlInjectorObj> processConfig(Collection<String> urls);    
 }

--- a/sparkler-core/sparkler-api/src/main/java/edu/usc/irds/sparkler/SparklerConfiguration.java
+++ b/sparkler-core/sparkler-api/src/main/java/edu/usc/irds/sparkler/SparklerConfiguration.java
@@ -18,6 +18,8 @@
 package edu.usc.irds.sparkler;
 
 import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -32,7 +34,7 @@ public class SparklerConfiguration extends JSONObject {
         super(map);
     }
 
-    public LinkedHashMap<String,Object> getPluginConfiguration(String pluginId) throws SparklerException {
+    public LinkedHashMap<String, Object> getPluginConfiguration(String pluginId) throws SparklerException {
         pluginId = pluginId.replace("-", ".");
         if (this.containsKey(Constants.key.PLUGINS)) {
             LinkedHashMap plugins = (LinkedHashMap) this.get(Constants.key.PLUGINS);
@@ -40,12 +42,12 @@ public class SparklerConfiguration extends JSONObject {
                 return (LinkedHashMap<String, Object>) plugins.get(pluginId);
             } else {
                 String[] parts = pluginId.split(":");
-                if (parts.length >= 3){ // groupId:artifactId:version
-                    //first check without version
+                if (parts.length >= 3) { // groupId:artifactId:version
+                    // first check without version
                     String newId = parts[0] + ":" + parts[1];
                     if (plugins.containsKey(newId)) {
                         return (LinkedHashMap<String, Object>) plugins.get(newId);
-                    } else if (plugins.containsKey(parts[1])){ // just the id, no groupId or version
+                    } else if (plugins.containsKey(parts[1])) { // just the id, no groupId or version
                         return (LinkedHashMap<String, Object>) plugins.get(parts[1]);
                     }
                 }
@@ -53,6 +55,17 @@ public class SparklerConfiguration extends JSONObject {
             }
         } else {
             throw new SparklerException("No plugin configuration found!");
+        }
+    }
+
+    public void overloadConfig(String object) {
+        JSONParser parser = new JSONParser();
+        JSONObject json;
+        try {
+            json = (JSONObject) parser.parse(object);
+            this.putAll(json);
+        } catch (ParseException e) {
+            e.printStackTrace();
         }
     }
 }

--- a/sparkler-core/sparkler-api/src/main/java/edu/usc/irds/sparkler/SparklerConfiguration.java
+++ b/sparkler-core/sparkler-api/src/main/java/edu/usc/irds/sparkler/SparklerConfiguration.java
@@ -64,17 +64,19 @@ public class SparklerConfiguration extends JSONObject {
 
     public void overloadConfig(String object) {
         JSONParser parser = new JSONParser();
-        JSONObject json;
-        try {
-            json = (JSONObject) parser.parse(object);
+        JSONObject json = null;
+            try{
+                json = (JSONObject) parser.parse(object);
+            } catch (Exception exception){
+                System.out.println("Error parsing overload json: " + exception+ " for json: "+object);
+                System.exit(0); // ???
+            }
+
             HashMap<String, Object> yourHashMap = new Gson().fromJson(json.toString(), HashMap.class);
             Map o = deepMerge(this, yourHashMap);
             JSONObject j = new JSONObject(this);
             String str = j.toJSONString();
             System.out.println(str);
-        } catch (ParseException e) {
-            e.printStackTrace();
-        }
     }
 
     private static Map deepMerge(Map original, Map newMap) {

--- a/sparkler-core/sparkler-api/src/main/java/edu/usc/irds/sparkler/UrlInjectorObj.java
+++ b/sparkler-core/sparkler-api/src/main/java/edu/usc/irds/sparkler/UrlInjectorObj.java
@@ -1,0 +1,26 @@
+package edu.usc.irds.sparkler;
+
+public class UrlInjectorObj {
+    private String url;
+    private String metadata;
+    private String httpMethod;
+
+    public UrlInjectorObj(String url, String metadata, String httpMethod){
+        this.url = url;
+        this.metadata = metadata;
+        this.httpMethod = httpMethod;
+    }
+
+
+    public String getUrl(){
+        return url;
+    }
+
+    public String getMetadata(){
+        return metadata;
+    }
+
+    public String getHttpMethod(){
+        return httpMethod;
+    }
+}

--- a/sparkler-core/sparkler-api/src/main/java/edu/usc/irds/sparkler/model/Resource.java
+++ b/sparkler-core/sparkler-api/src/main/java/edu/usc/irds/sparkler/model/Resource.java
@@ -188,4 +188,12 @@ public class Resource implements Serializable {
         return hm;
     }
 
+    public String getHttpMethod(){
+        if(this.httpMethod == null || this.httpMethod.equals("")){
+            return "GET";
+        } else{
+            return this.httpMethod;
+        }
+    }
+
 }

--- a/sparkler-core/sparkler-api/src/main/java/edu/usc/irds/sparkler/model/Resource.java
+++ b/sparkler-core/sparkler-api/src/main/java/edu/usc/irds/sparkler/model/Resource.java
@@ -34,6 +34,8 @@ public class Resource implements Serializable {
     @Field private String hostname;
     @Field private String parent;
     @Field("dedupe_id") private String dedupeId;
+    @Field("http_method") private String httpMethod;
+    @Field("metadata") private String metadata;
 
     public Resource() {
     }
@@ -63,7 +65,7 @@ public class Resource implements Serializable {
     }
 
     public Resource(String url, Integer discoverDepth, JobContext sparklerJob, ResourceStatus status,
-        String parent, Map<String, Double> score) throws MalformedURLException {
+        String parent, Map<String, Double> score, String metadata, String httpMethod) throws MalformedURLException {
         this(url, new URL(url).getHost(), sparklerJob);
         this.indexedAt = new Date();
         this.id = resourceId(url, sparklerJob, this.indexedAt);
@@ -71,6 +73,8 @@ public class Resource implements Serializable {
         this.status = status.toString();
         this.parent = parent;
         this.score = score;
+        this.httpMethod = httpMethod;
+        this.metadata = metadata;
     }
 
     public Resource(String url, Integer discoverDepth, JobContext sparklerJob, ResourceStatus status,
@@ -93,6 +97,7 @@ public class Resource implements Serializable {
 
         this(url, discoverDepth, sparklerJob, status, fetchTimestamp, parent);
         this.score = score;
+        
     }
 
     @Override

--- a/sparkler-core/sparkler-api/src/main/java/edu/usc/irds/sparkler/model/Resource.java
+++ b/sparkler-core/sparkler-api/src/main/java/edu/usc/irds/sparkler/model/Resource.java
@@ -196,4 +196,7 @@ public class Resource implements Serializable {
         }
     }
 
+    public String getMetadata(){
+        return this.metadata;
+    }
 }

--- a/sparkler-core/sparkler-api/src/main/java/edu/usc/irds/sparkler/util/FetcherDefault.java
+++ b/sparkler-core/sparkler-api/src/main/java/edu/usc/irds/sparkler/util/FetcherDefault.java
@@ -107,7 +107,7 @@ public class FetcherDefault extends AbstractExtensionPoint implements Fetcher, F
 
     public FetchedData fetch(Resource resource) throws Exception {
         LOG.info("DEFAULT FETCHER {}", resource.getUrl());
-        URLConnection urlConn = new URL(resource.getUrl()).openConnection();
+        HttpURLConnection urlConn = (HttpURLConnection) new URL(resource.getUrl()).openConnection();
         if (httpHeaders != null){
             httpHeaders.forEach(urlConn::setRequestProperty);
             LOG.debug("Adding headers:{}", httpHeaders.keySet());
@@ -124,6 +124,7 @@ public class FetcherDefault extends AbstractExtensionPoint implements Fetcher, F
 
         urlConn.setConnectTimeout(CONNECT_TIMEOUT);
         urlConn.setReadTimeout(READ_TIMEOUT);
+        urlConn.setRequestMethod(resource.getHttpMethod());
         int responseCode = ((HttpURLConnection)urlConn).getResponseCode();
         LOG.debug("STATUS CODE : " + responseCode + " " + resource.getUrl());
         boolean truncated = false;

--- a/sparkler-core/sparkler-api/src/main/java/edu/usc/irds/sparkler/util/FetcherDefault.java
+++ b/sparkler-core/sparkler-api/src/main/java/edu/usc/irds/sparkler/util/FetcherDefault.java
@@ -10,23 +10,31 @@ import edu.usc.irds.sparkler.model.FetchedData;
 import edu.usc.irds.sparkler.model.Resource;
 import edu.usc.irds.sparkler.model.ResourceStatus;
 import org.apache.commons.io.IOUtils;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -105,7 +113,19 @@ public class FetcherDefault extends AbstractExtensionPoint implements Fetcher, F
         return new StreamTransformer<>(resources, this);
     }
 
+    private void otherInit() throws SparklerException{
+        this.httpHeaders = new HashMap<String, String>();
+
+        this.httpHeaders.put("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko)");
+        this.httpHeaders.put("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8");
+        this.httpHeaders.put("Accept-Language", "en-US,en");
+        this.httpHeaders.put("Referer", "http://minnesota.magellanmedicaid.com/drug_search.asp");
+
+        
+    }
+
     public FetchedData fetch(Resource resource) throws Exception {
+        otherInit();
         LOG.info("DEFAULT FETCHER {}", resource.getUrl());
         HttpURLConnection urlConn = (HttpURLConnection) new URL(resource.getUrl()).openConnection();
         if (httpHeaders != null){
@@ -125,6 +145,22 @@ public class FetcherDefault extends AbstractExtensionPoint implements Fetcher, F
         urlConn.setConnectTimeout(CONNECT_TIMEOUT);
         urlConn.setReadTimeout(READ_TIMEOUT);
         urlConn.setRequestMethod(resource.getHttpMethod());
+        if(resource.getMetadata()!=null && !resource.getMetadata().equals("")){
+            JSONObject json = processMetadata(resource.getMetadata());
+    
+            if (json.containsKey("form")) {
+                urlConn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+                urlConn.setRequestProperty( "charset", "utf-8");
+                byte[] postData = processForm((JSONObject) json.get("form"));
+                urlConn.setRequestProperty( "Content-Length", Integer.toString( postData.length ));    
+                urlConn.setDoOutput(true);
+                try( DataOutputStream wr = new DataOutputStream( urlConn.getOutputStream())) {
+                    wr.write( postData );
+                 }
+            } else if (json.containsKey("json")) {
+                //processJson((JSONObject) json.get("json"), connection);
+            }
+        }
         int responseCode = ((HttpURLConnection)urlConn).getResponseCode();
         LOG.debug("STATUS CODE : " + responseCode + " " + resource.getUrl());
         boolean truncated = false;
@@ -171,5 +207,43 @@ public class FetcherDefault extends AbstractExtensionPoint implements Fetcher, F
             fetchedData.setResource(resource);
             return fetchedData;
         }
+    }
+
+    private void processJson(JSONObject object, HttpURLConnection conn) {
+
+    }
+
+    private byte[] processForm(JSONObject object) {
+        Set keys = object.keySet();
+        Iterator keyIter = keys.iterator();
+        String content = "";
+        for (int i = 0; keyIter.hasNext(); i++) {
+            Object key = keyIter.next();
+            if (i != 0) {
+                content += "&";
+            }
+            try {
+                content += key + "=" + URLEncoder.encode((String) object.get(key), "UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                e.printStackTrace();
+            }
+        }
+        return content.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private JSONObject processMetadata(String metadata) {
+        if(metadata != null){
+            JSONParser parser = new JSONParser();
+            JSONObject json;
+            try {
+                json = (JSONObject) parser.parse(metadata);
+                return json;
+                
+            } catch (ParseException e) {
+                e.printStackTrace();
+            }
+        }
+        return null;
+
     }
 }

--- a/sparkler-core/sparkler-api/src/main/java/edu/usc/irds/sparkler/util/FetcherDefault.java
+++ b/sparkler-core/sparkler-api/src/main/java/edu/usc/irds/sparkler/util/FetcherDefault.java
@@ -24,7 +24,6 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.net.URLConnection;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -113,19 +112,7 @@ public class FetcherDefault extends AbstractExtensionPoint implements Fetcher, F
         return new StreamTransformer<>(resources, this);
     }
 
-    private void otherInit() throws SparklerException{
-        this.httpHeaders = new HashMap<String, String>();
-
-        this.httpHeaders.put("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko)");
-        this.httpHeaders.put("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8");
-        this.httpHeaders.put("Accept-Language", "en-US,en");
-        this.httpHeaders.put("Referer", "http://minnesota.magellanmedicaid.com/drug_search.asp");
-
-        
-    }
-
     public FetchedData fetch(Resource resource) throws Exception {
-        otherInit();
         LOG.info("DEFAULT FETCHER {}", resource.getUrl());
         HttpURLConnection urlConn = (HttpURLConnection) new URL(resource.getUrl()).openConnection();
         if (httpHeaders != null){

--- a/sparkler-core/sparkler-app/build.sbt
+++ b/sparkler-core/sparkler-app/build.sbt
@@ -21,7 +21,7 @@ javacOptions ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "edu.usc.irds.sparkler" % "sparkler-api" % "0.2.1-SNAPSHOT",
+  "edu.usc.irds.sparkler" % "sparkler-api" % "0.2.2-SNAPSHOT",
   "org.pf4j" % "pf4j" % "2.0.0",
   "org.apache.spark" % "spark-core_2.11" % "1.6.1",
   "org.apache.nutch" % "nutch" % "1.13",

--- a/sparkler-core/sparkler-app/pom.xml
+++ b/sparkler-core/sparkler-app/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>sparkler-parent</artifactId>
         <groupId>edu.usc.irds.sparkler</groupId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.2.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sparkler-core/sparkler-app/pom.xml
+++ b/sparkler-core/sparkler-app/pom.xml
@@ -217,9 +217,9 @@
                             </transformers>
                             <relocations>
                                 <!-- To resolve dependency conflict with Spark -->
-                                <relocation> 
-                                    <pattern>org.apache.http</pattern> 
-                                    <shadedPattern>shaded.org.apache.http</shadedPattern> 
+                                <relocation>
+                                    <pattern>org.apache.http</pattern>
+                                    <shadedPattern>shaded.org.apache.http</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/Crawler.scala
+++ b/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/Crawler.scala
@@ -116,6 +116,7 @@ class Crawler extends CliTool {
 
 
   @Option(name = "-co", aliases = Array("--config-override"),
+    handler = classOf[StringArrayOptionHandler],
     usage = "Configuration override. JSON Blob, key values in this take priority over config values in the config file.")
   var configOverride: String = ""
 
@@ -130,7 +131,7 @@ class Crawler extends CliTool {
 
   def init(): Unit = {
     if (configOverride != ""){
-      sparklerConf.overloadConfig(configOverride);
+      sparklerConf.overloadConfig(configOverride.mkString(" "));
     }
     if (this.outputPath.isEmpty) {
       this.outputPath = jobId

--- a/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/Crawler.scala
+++ b/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/Crawler.scala
@@ -118,7 +118,7 @@ class Crawler extends CliTool {
   @Option(name = "-co", aliases = Array("--config-override"),
     handler = classOf[StringArrayOptionHandler],
     usage = "Configuration override. JSON Blob, key values in this take priority over config values in the config file.")
-  var configOverride: String = ""
+  var configOverride: Array[Any] = Array()
 
   /* Generator options, currently not exposed via the CLI
      and only accessible through the config yaml file
@@ -131,6 +131,7 @@ class Crawler extends CliTool {
 
   def init(): Unit = {
     if (configOverride != ""){
+      print(configOverride.mkString(" "))
       sparklerConf.overloadConfig(configOverride.mkString(" "));
     }
     if (this.outputPath.isEmpty) {

--- a/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/Crawler.scala
+++ b/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/Crawler.scala
@@ -113,6 +113,12 @@ class Crawler extends CliTool {
   @Option(name = "-dcf", forbids = Array("-dc"),
     aliases = Array("--deepcrawl-file"), usage = "Deep crawl the provided hosts in the line separated file")
   var deepCrawlHostFile : File = _
+
+
+  @Option(name = "-co", aliases = Array("--config-override"),
+    usage = "Configuration override. JSON Blob, key values in this take priority over config values in the config file.")
+  var configOverride: String = ""
+
   /* Generator options, currently not exposed via the CLI
      and only accessible through the config yaml file
    */
@@ -123,6 +129,9 @@ class Crawler extends CliTool {
   var sc: SparkContext = _
 
   def init(): Unit = {
+    if (configOverride != ""){
+      sparklerConf.overloadConfig(configOverride);
+    }
     if (this.outputPath.isEmpty) {
       this.outputPath = jobId
     }

--- a/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/FetchFunction.scala
+++ b/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/FetchFunction.scala
@@ -34,13 +34,18 @@ object FetchFunction
     with Serializable with Loggable {
   val FETCH_TIMEOUT = 1000
   val defaultFetcher = new FetcherDefault
-
+  var initialised = false
   def init(job:SparklerJob): Unit ={
     defaultFetcher.init(job,"")
+    initialised = true
   }
 
   override def apply(job: SparklerJob, resources: Iterator[Resource])
   : Iterator[FetchedData] = {
+    if(!initialised){
+      LOG.debug("INITIALIZING CRAWLER")
+      init(job)
+    }
     val fetcher:scala.Option[Fetcher] = PluginService.getExtension(classOf[Fetcher], job)
     try {
      (fetcher match {case Some(f) => f; case None => defaultFetcher}).fetch(resources)

--- a/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/ParseFunction.scala
+++ b/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/ParseFunction.scala
@@ -71,8 +71,8 @@ object ParseFunction extends ((CrawlData) => (ParsedData)) with Serializable wit
       parseData.metadata = meta
     } catch {
       case e: Throwable =>
-        LOG.warn("PARSING-CONTENT-ERROR {}", data.fetchedData.getResource.getUrl)
-        LOG.warn(e.getMessage, e)
+        LOG.warn("PARSING-CONTENT-ERROR {}", data.fetchedData.getResource.getUrl + " " + e.getMessage())
+        LOG.debug(e.getMessage, e)
         parseData
     } finally { IOUtils.closeQuietly(stream) }
 

--- a/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/UrlInjectorFunction.scala
+++ b/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/UrlInjectorFunction.scala
@@ -7,25 +7,30 @@ import edu.usc.irds.sparkler.model._
 import scala.collection.JavaConversions._
 import java.util.ArrayList
 import java.util
-
-object UrlInjectorFunction extends ((SparklerJob, util.Collection[String]) => util.Collection[String]) with Serializable with Loggable{
+import edu.usc.irds.sparkler.UrlInjectorObj
+object UrlInjectorFunction extends ((SparklerJob, util.Collection[String]) => util.Collection[UrlInjectorObj]) with Serializable with Loggable{
 
  override def apply(job: SparklerJob, resources: util.Collection[String])
-  : util.Collection[String] = {
+  : util.Collection[UrlInjectorObj] = {
     val fetcher:scala.Option[Config] = PluginService.getExtension(classOf[Config], job)
-    val a = new ArrayList[String]
     try {
       fetcher match {
         case Some(fetcher) =>
-          val score = fetcher.processConfig()
+          val score = fetcher.processConfig(resources)
           score
         case None =>
-          resources
+          convertToUrlInjector(resources)
       }
     } catch {
       case e: Exception =>
         LOG.error(e.getMessage, e)
-        resources
+        convertToUrlInjector(resources)
     }
+  }
+
+  def convertToUrlInjector( lst:util.Collection[String]) : util.Collection[UrlInjectorObj] = {
+    var c = List()
+    lst.toList.foreach{ node =>  val uio = new UrlInjectorObj(node, null, null);  c :+ uio  }
+    c
   }
 }

--- a/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/UrlInjectorFunction.scala
+++ b/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/UrlInjectorFunction.scala
@@ -29,8 +29,11 @@ object UrlInjectorFunction extends ((SparklerJob, util.Collection[String]) => ut
   }
 
   def convertToUrlInjector( lst:util.Collection[String]) : util.Collection[UrlInjectorObj] = {
-    var c = List()
-    lst.toList.foreach{ node =>  val uio = new UrlInjectorObj(node, null, null);  c :+ uio  }
+    var c = List[UrlInjectorObj]()
+     lst.forEach(n => {
+           val uio = new UrlInjectorObj(n, null, null)
+          c = uio :: c
+    })
     c
   }
 }

--- a/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/UrlInjectorFunction.scala
+++ b/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/pipeline/UrlInjectorFunction.scala
@@ -1,0 +1,31 @@
+package edu.usc.irds.sparkler.pipeline
+
+import edu.usc.irds.sparkler.Config
+import edu.usc.irds.sparkler.base.Loggable
+import edu.usc.irds.sparkler.service.PluginService
+import edu.usc.irds.sparkler.model._
+import scala.collection.JavaConversions._
+import java.util.ArrayList
+import java.util
+
+object UrlInjectorFunction extends ((SparklerJob, util.Collection[String]) => util.Collection[String]) with Serializable with Loggable{
+
+ override def apply(job: SparklerJob, resources: util.Collection[String])
+  : util.Collection[String] = {
+    val fetcher:scala.Option[Config] = PluginService.getExtension(classOf[Config], job)
+    val a = new ArrayList[String]
+    try {
+      fetcher match {
+        case Some(fetcher) =>
+          val score = fetcher.processConfig()
+          score
+        case None =>
+          resources
+      }
+    } catch {
+      case e: Exception =>
+        LOG.error(e.getMessage, e)
+        resources
+    }
+  }
+}

--- a/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/service/Injector.scala
+++ b/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/service/Injector.scala
@@ -24,6 +24,7 @@ import java.util
 import edu.usc.irds.sparkler.{Constants, SparklerConfiguration}
 import edu.usc.irds.sparkler.base.{CliTool, Loggable}
 import edu.usc.irds.sparkler.model.{Resource, ResourceStatus, SparklerJob}
+import edu.usc.irds.sparkler.pipeline.UrlInjectorFunction
 import edu.usc.irds.sparkler.util.JobUtil
 import org.kohsuke.args4j.Option
 import org.kohsuke.args4j.spi.StringArrayOptionHandler
@@ -89,9 +90,10 @@ class Injector extends CliTool {
         seedUrls.toList
       }
 
+    val replacedUrls = UrlInjectorFunction(job, urls)
     // TODO: Add URL normalizer and filters before injecting the seeds
     val seeds: util.Collection[Resource] =
-      urls.map(_.trim)
+      replacedUrls.map(_.trim)
         .filter(url => urlValidator.isValid(url))
         .map(x => new Resource(x, 0, job, ResourceStatus.UNFETCHED, Injector.SEED_PARENT, Injector.SEED_SCORE))
     LOG.info("Injecting {} seeds", seeds.size())

--- a/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/service/Injector.scala
+++ b/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/service/Injector.scala
@@ -68,7 +68,14 @@ class Injector extends CliTool {
     usage = "Crawdb URI.")
   var sparkSolr: String = conf.get(Constants.key.CRAWLDB).asInstanceOf[String]
 
+    @Option(name = "-co", aliases = Array("--config-override"),
+    usage = "Configuration override. JSON Blob, key values in this take priority over config values in the config file.")
+  var configOverride: String = ""
+
   override def run(): Unit = {
+    if (configOverride != ""){
+      conf.overloadConfig(configOverride);
+    }
     if (!sparkSolr.isEmpty) {
       val uri = conf.asInstanceOf[java.util.HashMap[String, String]]
       uri.put("crawldb.uri", sparkSolr)

--- a/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/service/Injector.scala
+++ b/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/service/Injector.scala
@@ -26,7 +26,6 @@ import edu.usc.irds.sparkler.base.{CliTool, Loggable}
 import edu.usc.irds.sparkler.model.{Resource, ResourceStatus, SparklerJob}
 import edu.usc.irds.sparkler.pipeline.UrlInjectorFunction
 import edu.usc.irds.sparkler.util.JobUtil
-import edu.usc.irds.sparkler.service.WellBehavedStringArrayOptionHandler
 import org.kohsuke.args4j.Option
 import org.kohsuke.args4j.spi.StringArrayOptionHandler
 

--- a/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/service/Injector.scala
+++ b/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/service/Injector.scala
@@ -26,6 +26,7 @@ import edu.usc.irds.sparkler.base.{CliTool, Loggable}
 import edu.usc.irds.sparkler.model.{Resource, ResourceStatus, SparklerJob}
 import edu.usc.irds.sparkler.pipeline.UrlInjectorFunction
 import edu.usc.irds.sparkler.util.JobUtil
+import edu.usc.irds.sparkler.service.WellBehavedStringArrayOptionHandler
 import org.kohsuke.args4j.Option
 import org.kohsuke.args4j.spi.StringArrayOptionHandler
 
@@ -68,13 +69,14 @@ class Injector extends CliTool {
     usage = "Crawdb URI.")
   var sparkSolr: String = conf.get(Constants.key.CRAWLDB).asInstanceOf[String]
 
-    @Option(name = "-co", aliases = Array("--config-override"),
+  @Option(name = "-co", aliases = Array("--config-override"),
+    handler = classOf[StringArrayOptionHandler],
     usage = "Configuration override. JSON Blob, key values in this take priority over config values in the config file.")
-  var configOverride: String = ""
+  var configOverride: Array[Any] = Array()
 
   override def run(): Unit = {
     if (configOverride != ""){
-      conf.overloadConfig(configOverride);
+      conf.overloadConfig(configOverride.mkString(" "));
     }
     if (!sparkSolr.isEmpty) {
       val uri = conf.asInstanceOf[java.util.HashMap[String, String]]

--- a/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/service/Injector.scala
+++ b/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/service/Injector.scala
@@ -92,10 +92,13 @@ class Injector extends CliTool {
 
     val replacedUrls = UrlInjectorFunction(job, urls)
     // TODO: Add URL normalizer and filters before injecting the seeds
-    val seeds: util.Collection[Resource] =
-      replacedUrls.map(_.trim)
-        .filter(url => urlValidator.isValid(url))
-        .map(x => new Resource(x, 0, job, ResourceStatus.UNFETCHED, Injector.SEED_PARENT, Injector.SEED_SCORE))
+    var seeds = List[Resource]()
+    replacedUrls.forEach(n => {
+        if(urlValidator.isValid(n.getUrl)){
+          val res = new Resource(n.getUrl.trim, 0, job, ResourceStatus.UNFETCHED, Injector.SEED_PARENT, Injector.SEED_SCORE, n.getMetadata, n.getHttpMethod)
+          seeds = res :: seeds
+        }
+    })
     LOG.info("Injecting {} seeds", seeds.size())
 
     val solrClient = job.newCrawlDbSolrClient()

--- a/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/service/PluginService.scala
+++ b/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/service/PluginService.scala
@@ -70,8 +70,11 @@ class PluginService(job:SparklerJob) {
       if (pw == null){ throw new Exception(s"Failed to load extension $pluginId") }
       pluginManager.startPlugin(pluginId)
       val exts = pluginManager.getExtensions(pluginId)
+      LOG.info(s"Extensions found: $exts")
       for (ext <- exts){
         class2Id(ext.getClass.getName) = pw.getPluginId
+        LOG.info(s"Extensions lookup: $pw.getPluginId")
+        LOG.info(s"Extensions id lookup: $ext.getClass.getName")
         id2Class(pw.getPluginId) = ext.getClass.getName
       }
     }

--- a/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/service/SolrProxy.scala
+++ b/sparkler-core/sparkler-app/src/main/scala/edu/usc/irds/sparkler/service/SolrProxy.scala
@@ -40,7 +40,7 @@ class SolrProxy(var crawlDb: SolrClient) extends Closeable with Loggable {
       crawlDb.addBeans(beans)
     } catch {
       case e: Exception =>
-        LOG.debug("Caught {} while adding beans, trying to add one by one", e.getMessage)
+        LOG.warn("Caught {} while adding beans, trying to add one by one", e.getMessage)
         while (beans.hasNext) {
           val bean = beans.next()
           try { // to add one by one

--- a/sparkler-core/sparkler-plugins/fetcher-chrome/pom.xml
+++ b/sparkler-core/sparkler-plugins/fetcher-chrome/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>com.browserup</groupId>
             <artifactId>browserup-proxy-core</artifactId>
-            <version>1.0.0</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/sparkler-core/sparkler-plugins/fetcher-chrome/pom.xml
+++ b/sparkler-core/sparkler-plugins/fetcher-chrome/pom.xml
@@ -83,6 +83,27 @@
                 </exclusion>
             </exclusions>
 		</dependency>
+        <dependency>
+            <groupId>com.browserup</groupId>
+            <artifactId>browserup-proxy-core</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+            <version>4.0.15.Final</version>
+        </dependency>
+
     </dependencies>
     <build>
         <plugins>

--- a/sparkler-core/sparkler-plugins/fetcher-chrome/pom.xml
+++ b/sparkler-core/sparkler-plugins/fetcher-chrome/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>sparkler-plugins</artifactId>
         <groupId>edu.usc.irds.sparkler.plugin</groupId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.2.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sparkler-core/sparkler-plugins/fetcher-chrome/src/main/java/edu/usc/irds/sparkler/plugin/FetcherChrome.java
+++ b/sparkler-core/sparkler-plugins/fetcher-chrome/src/main/java/edu/usc/irds/sparkler/plugin/FetcherChrome.java
@@ -154,9 +154,6 @@ public class FetcherChrome extends FetcherDefault {
         if(resource.getMetadata()!=null && !resource.getMetadata().equals("")){
         JSONObject json = processMetadata(resource.getMetadata());
 
-        //URL url = new URL(resource.getUrl());
-        //HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-
         if (json.containsKey("form")) {
             //processForm((JSONObject) json.get("form"), connection);
             //connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
@@ -169,11 +166,6 @@ public class FetcherChrome extends FetcherDefault {
         // associated AJAX requests
         driver.get(resource.getUrl());
         
-        //connection.setRequestMethod(resource.getHttpMethod());
-        //connection.connect();
-
-        //int status = connection.getResponseCode();
-
         int waittimeout = (int) pluginConfig.getOrDefault("chrome.wait.timeout", "-1");
         String waittype = (String) pluginConfig.getOrDefault("chrome.wait.type", "");
         String waitelement = (String) pluginConfig.getOrDefault("chrome.wait.element", "");

--- a/sparkler-core/sparkler-plugins/fetcher-chrome/src/main/java/edu/usc/irds/sparkler/plugin/FetcherChrome.java
+++ b/sparkler-core/sparkler-plugins/fetcher-chrome/src/main/java/edu/usc/irds/sparkler/plugin/FetcherChrome.java
@@ -55,7 +55,7 @@ import java.net.URLConnection;
 import java.net.URLEncoder;
 import java.net.UnknownHostException;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Map;
 import java.util.Set;
 
@@ -74,7 +74,7 @@ import org.openqa.selenium.Proxy;
 public class FetcherChrome extends FetcherDefault {
 
     private static final Logger LOG = LoggerFactory.getLogger(FetcherChrome.class);
-    private LinkedHashMap<String, Object> pluginConfig;
+    private Map<String, Object> pluginConfig;
     private WebDriver driver;
     private WebElement clickedEl = null;
     private int latestStatus;

--- a/sparkler-core/sparkler-plugins/fetcher-chrome/src/main/java/edu/usc/irds/sparkler/plugin/FetcherChrome.java
+++ b/sparkler-core/sparkler-plugins/fetcher-chrome/src/main/java/edu/usc/irds/sparkler/plugin/FetcherChrome.java
@@ -115,7 +115,7 @@ public class FetcherChrome extends FetcherDefault {
 
         URL url = new URL(resource.getUrl());
         HttpURLConnection connection = (HttpURLConnection)url.openConnection();
-        connection.setRequestMethod("GET");
+        connection.setRequestMethod(resource.getHttpMethod());
         connection.connect();
 
         int status = connection.getResponseCode();

--- a/sparkler-core/sparkler-plugins/fetcher-chrome/src/main/java/edu/usc/irds/sparkler/plugin/FetcherChrome.java
+++ b/sparkler-core/sparkler-plugins/fetcher-chrome/src/main/java/edu/usc/irds/sparkler/plugin/FetcherChrome.java
@@ -206,7 +206,7 @@ public class FetcherChrome extends FetcherDefault {
             LOG.info("{} Failed to fetch the page. Falling back to default fetcher.", resource.getUrl());
             return super.fetch(resource);
         }
-        //fetchedData = new FetchedData(html.getBytes(), "application/html", status);
+
         fetchedData = new FetchedData(html.getBytes(), "application/html", latestStatus);
         resource.setStatus(ResourceStatus.FETCHED.toString());
         fetchedData.setResource(resource);

--- a/sparkler-core/sparkler-plugins/fetcher-chrome/src/main/java/edu/usc/irds/sparkler/plugin/FetcherChrome.java
+++ b/sparkler-core/sparkler-plugins/fetcher-chrome/src/main/java/edu/usc/irds/sparkler/plugin/FetcherChrome.java
@@ -26,12 +26,19 @@ import edu.usc.irds.sparkler.model.ResourceStatus;
 import edu.usc.irds.sparkler.util.FetcherDefault;
 
 import org.apache.commons.lang.ArrayUtils;
+import org.apache.http.HttpException;
+import org.apache.http.HttpResponseInterceptor;
+import org.apache.http.protocol.HttpContext;
 import org.eclipse.jetty.util.ArrayUtil;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -40,14 +47,34 @@ import org.pf4j.Extension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.net.URLEncoder;
+import java.net.UnknownHostException;
+import java.nio.channels.SelectionKey;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
+
+import com.browserup.bup.BrowserUpProxy;
+import com.browserup.bup.BrowserUpProxyServer;
+import com.browserup.bup.client.ClientUtil;
+import com.browserup.bup.filters.ResponseFilter;
+import com.browserup.bup.proxy.CaptureType;
+import com.browserup.bup.util.HttpMessageContents;
+import com.browserup.bup.util.HttpMessageInfo;
+import com.browserup.harreader.model.Har;
+import io.netty.handler.codec.http.HttpResponse;
+
+import org.openqa.selenium.Proxy;
 
 @Extension
 public class FetcherChrome extends FetcherDefault {
@@ -57,31 +84,46 @@ public class FetcherChrome extends FetcherDefault {
     private LinkedHashMap<String, Object> pluginConfig;
     private WebDriver driver;
     private WebElement clickedEl = null;
-
-
+    private int latestStatus;
     @Override
     public void init(JobContext context, String pluginId) throws SparklerException {
         super.init(context, pluginId);
 
         SparklerConfiguration config = jobContext.getConfiguration();
-        //TODO should change everywhere 
+        // TODO should change everywhere
         pluginConfig = config.getPluginConfiguration(pluginId);
 
-
-
         String loc = (String) pluginConfig.getOrDefault("chrome.dns", "");
-        if(loc.equals("")){
+        if (loc.equals("")) {
             driver = new ChromeDriver();
-        }
-        else{
+        } else {
             try {
-                final DesiredCapabilities desiredCapabilities = DesiredCapabilities.chrome();
+                BrowserUpProxy proxy = new BrowserUpProxyServer();
+                Proxy seleniumProxy = ClientUtil.createSeleniumProxy(proxy);
+                proxy.setTrustAllServers(true);
+                
+                proxy.enableHarCaptureTypes(CaptureType.REQUEST_CONTENT, CaptureType.RESPONSE_CONTENT);
+                proxy.addResponseFilter(new ResponseFilter() {
+                    @Override
+                    public void filterResponse(HttpResponse response, HttpMessageContents contents, HttpMessageInfo messageInfo) {
+                        latestStatus = response.getStatus().code();
+                    }
+                });
+                proxy.start();
+                
+                int port = proxy.getPort();
+
+                seleniumProxy.setHttpProxy("172.17.146.238:"+Integer.toString(port));
+                seleniumProxy.setSslProxy("172.17.146.238:"+Integer.toString(port));
+                DesiredCapabilities capabilities = DesiredCapabilities.chrome();
                 final ChromeOptions chromeOptions = new ChromeOptions();
                 chromeOptions.addArguments("--no-sandbox");
                 chromeOptions.addArguments("--headless");
-                desiredCapabilities.setCapability(ChromeOptions.CAPABILITY, chromeOptions);
+                chromeOptions.addArguments("--ignore-certificate-errors");
+                capabilities.setCapability(CapabilityType.PROXY, seleniumProxy);
+                capabilities.setCapability(ChromeOptions.CAPABILITY, chromeOptions);
 
-                driver = new RemoteWebDriver(new URL(loc), desiredCapabilities);
+                driver = new RemoteWebDriver(new URL(loc), capabilities);
             } catch (MalformedURLException e) {
                 e.printStackTrace();
             }
@@ -95,74 +137,133 @@ public class FetcherChrome extends FetcherDefault {
         LOG.info("Chrome FETCHER {}", resource.getUrl());
         FetchedData fetchedData;
         /*
-		* In this plugin we will work on only HTML data
-		* If data is of any other data type like image, pdf etc plugin will return client error
-		* so it can be fetched using default Fetcher
-		*/
+         * In this plugin we will work on only HTML data If data is of any other data
+         * type like image, pdf etc plugin will return client error so it can be fetched
+         * using default Fetcher
+         */
         if (!isWebPage(resource.getUrl())) {
             LOG.debug("{} not a html. Falling back to default fetcher.", resource.getUrl());
-            //This should be true for all URLS ending with 4 character file extension
-            //return new FetchedData("".getBytes(), "application/html", ERROR_CODE) ;
+            // This should be true for all URLS ending with 4 character file extension
+            // return new FetchedData("".getBytes(), "application/html", ERROR_CODE) ;
             return super.fetch(resource);
         }
         long start = System.currentTimeMillis();
 
         LOG.debug("Time taken to create driver- {}", (System.currentTimeMillis() - start));
 
+        if(resource.getMetadata()!=null && !resource.getMetadata().equals("")){
+        JSONObject json = processMetadata(resource.getMetadata());
+
+        //URL url = new URL(resource.getUrl());
+        //HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+
+        if (json.containsKey("form")) {
+            //processForm((JSONObject) json.get("form"), connection);
+            //connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+
+        } else if (json.containsKey("json")) {
+            //processJson((JSONObject) json.get("json"), connection);
+        }
+    }
         // This will block for the page load and any
         // associated AJAX requests
         driver.get(resource.getUrl());
+        
+        //connection.setRequestMethod(resource.getHttpMethod());
+        //connection.connect();
 
-        URL url = new URL(resource.getUrl());
-        HttpURLConnection connection = (HttpURLConnection)url.openConnection();
-        connection.setRequestMethod(resource.getHttpMethod());
-        connection.connect();
-
-        int status = connection.getResponseCode();
-        //content-type
-
-        // Returns the page source in its current state, including
-        // any DOM updates that occurred after page load
-
-        //quitBrowserInstance(driver);
+        //int status = connection.getResponseCode();
 
         int waittimeout = (int) pluginConfig.getOrDefault("chrome.wait.timeout", "-1");
         String waittype = (String) pluginConfig.getOrDefault("chrome.wait.type", "");
         String waitelement = (String) pluginConfig.getOrDefault("chrome.wait.element", "");
 
-        if(waittimeout > -1){
-            LOG.debug("Waiting {} seconds for element {} of type {} to become visible", waittimeout, waitelement, waittype);
+        if (waittimeout > -1) {
+            LOG.debug("Waiting {} seconds for element {} of type {} to become visible", waittimeout, waitelement,
+                    waittype);
             WebDriverWait wait = new WebDriverWait(driver, waittimeout);
-            if(waittype.equals("class")){
+            if (waittype.equals("class")) {
                 LOG.debug("waiting for class...");
                 wait.until(ExpectedConditions.visibilityOfElementLocated(By.className(waitelement)));
-            } else if(waittype.equals("name")){
+            } else if (waittype.equals("name")) {
                 LOG.debug("waiting for name...");
                 wait.until(ExpectedConditions.visibilityOfElementLocated(By.name(waitelement)));
-            } else if(waittype.equals("id")){
+            } else if (waittype.equals("id")) {
                 LOG.debug("waiting for id...");
                 wait.until(ExpectedConditions.visibilityOfElementLocated(By.id(waitelement)));
             }
         }
-
-        if (pluginConfig.get("chrome.selenium.enabled").equals("true")){
+        String seleniumenabled = (String) pluginConfig.getOrDefault("chrome.selenium.enabled", "false");
+        if (seleniumenabled.equals("true")) {
             runScript(pluginConfig.get("chrome.selenium.script"));
         }
-        
+
         String html = driver.getPageSource();
 
         LOG.debug("Time taken to load {} - {} ", resource.getUrl(), (System.currentTimeMillis() - start));
 
-        if (!(status >= 200 && status < 300)) {
+        if (!(latestStatus >= 200 && latestStatus < 300)) {
             // If not fetched through plugin successfully
             // Falling back to default fetcher
             LOG.info("{} Failed to fetch the page. Falling back to default fetcher.", resource.getUrl());
             return super.fetch(resource);
         }
-        fetchedData = new FetchedData(html.getBytes(), "application/html", status);
+        //fetchedData = new FetchedData(html.getBytes(), "application/html", status);
+        fetchedData = new FetchedData(html.getBytes(), "application/html", latestStatus);
         resource.setStatus(ResourceStatus.FETCHED.toString());
         fetchedData.setResource(resource);
         return fetchedData;
+    }
+
+    private void processJson(JSONObject object, HttpURLConnection conn) {
+
+    }
+
+    private void processForm(JSONObject object, HttpURLConnection conn) {
+        Set keys = object.keySet();
+        Iterator keyIter = keys.iterator();
+        String content = "";
+        for (int i = 0; keyIter.hasNext(); i++) {
+            Object key = keyIter.next();
+            if (i != 0) {
+                content += "&";
+            }
+            try {
+                content += key + "=" + URLEncoder.encode((String) object.get(key), "UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                e.printStackTrace();
+            }
+        }
+        System.out.println(content);
+        try {
+            DataOutputStream out = new DataOutputStream(conn.getOutputStream());
+            out.writeBytes(content);
+            out.flush();
+            out.close();
+        } catch (IOException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+        //out.writeBytes(content);
+        //out.flush();
+        //out.close();
+    
+    }
+
+    private JSONObject processMetadata(String metadata) {
+        if(metadata != null){
+            JSONParser parser = new JSONParser();
+            JSONObject json;
+            try {
+                json = (JSONObject) parser.parse(metadata);
+                return json;
+                
+            } catch (ParseException e) {
+                e.printStackTrace();
+            }
+        }
+        return null;
+
     }
 
     private void runScript(Object orDefault) {

--- a/sparkler-core/sparkler-plugins/fetcher-htmlunit/pom.xml
+++ b/sparkler-core/sparkler-plugins/fetcher-htmlunit/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>sparkler-plugins</artifactId>
         <groupId>edu.usc.irds.sparkler.plugin</groupId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.2.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sparkler-core/sparkler-plugins/fetcher-htmlunit/src/main/java/edu/usc/irds/sparkler/plugin/HtmlUnitFetcher.java
+++ b/sparkler-core/sparkler-plugins/fetcher-htmlunit/src/main/java/edu/usc/irds/sparkler/plugin/HtmlUnitFetcher.java
@@ -18,9 +18,11 @@
 package edu.usc.irds.sparkler.plugin;
 
 import com.gargoylesoftware.htmlunit.BrowserVersion;
+import com.gargoylesoftware.htmlunit.HttpMethod;
 import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.WebClientOptions;
+import com.gargoylesoftware.htmlunit.WebRequest;
 import com.gargoylesoftware.htmlunit.WebResponse;
 import com.gargoylesoftware.htmlunit.util.NameValuePair;
 import edu.usc.irds.sparkler.JobContext;
@@ -38,12 +40,12 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 
 /**
  * This class has implements {@link edu.usc.irds.sparkler.Fetcher} using
@@ -51,7 +53,7 @@ import java.util.Map;
  *
  */
 @Extension
-public class HtmlUnitFetcher extends FetcherDefault  implements AutoCloseable {
+public class HtmlUnitFetcher extends FetcherDefault implements AutoCloseable {
 
     private static final Integer DEFAULT_TIMEOUT = 2000;
     private static final Integer DEFAULT_JS_TIMEOUT = 2000;
@@ -61,7 +63,7 @@ public class HtmlUnitFetcher extends FetcherDefault  implements AutoCloseable {
     @Override
     public void init(JobContext context, String pluginId) throws SparklerException {
         super.init(context, pluginId);
-        //TODO: get timeouts from configurations
+        // TODO: get timeouts from configurations
         driver = new WebClient(BrowserVersion.BEST_SUPPORTED);
         driver.setJavaScriptTimeout(DEFAULT_JS_TIMEOUT);
         WebClientOptions options = driver.getOptions();
@@ -96,7 +98,15 @@ public class HtmlUnitFetcher extends FetcherDefault  implements AutoCloseable {
                 driver.removeRequestHeader(USER_AGENT);
                 driver.addRequestHeader(USER_AGENT, userAgent);
             }
-            Page page = driver.getPage(resource.getUrl());
+            HttpMethod method = HttpMethod.GET;
+            if(resource.getHttpMethod().equals("PUT")){
+                method = HttpMethod.PUT;
+            } else if(resource.getHttpMethod().equals("POST")){
+                method = HttpMethod.POST;
+            }
+            URL url = new URL(resource.getUrl());
+            WebRequest requestSettings = new WebRequest(url, method);
+            Page page = driver.getPage(requestSettings);
 
             WebResponse response = page.getWebResponse();
             boolean truncated = false;

--- a/sparkler-core/sparkler-plugins/fetcher-jbrowser/pom.xml
+++ b/sparkler-core/sparkler-plugins/fetcher-jbrowser/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>sparkler-plugins</artifactId>
         <groupId>edu.usc.irds.sparkler.plugin</groupId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.2.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sparkler-core/sparkler-plugins/fetcher-jbrowser/src/main/java/edu/usc/irds/sparkler/plugin/FetcherJBrowser.java
+++ b/sparkler-core/sparkler-plugins/fetcher-jbrowser/src/main/java/edu/usc/irds/sparkler/plugin/FetcherJBrowser.java
@@ -33,14 +33,14 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URL;
 import java.net.URLConnection;
-import java.util.LinkedHashMap;
+import java.util.Map;
 
 @Extension
 public class FetcherJBrowser extends FetcherDefault {
 
     private static final Integer DEFAULT_TIMEOUT = 2000;
     private static final Logger LOG = LoggerFactory.getLogger(FetcherJBrowser.class);
-    private LinkedHashMap<String, Object> pluginConfig;
+    private Map<String, Object> pluginConfig;
     private JBrowserDriver driver;
 
 

--- a/sparkler-core/sparkler-plugins/pom.xml
+++ b/sparkler-core/sparkler-plugins/pom.xml
@@ -39,6 +39,7 @@
         <module>fetcher-htmlunit</module>
         <module>fetcher-chrome</module>
         <module>urlfilter-samehost</module>
+        <module>url-injector</module>
         <!-- Copy template plugin to create a new plugin-->
         <module>template-plugin</module>
     </modules>

--- a/sparkler-core/sparkler-plugins/pom.xml
+++ b/sparkler-core/sparkler-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>sparkler-parent</artifactId>
         <groupId>edu.usc.irds.sparkler</groupId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.2.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>edu.usc.irds.sparkler.plugin</groupId>

--- a/sparkler-core/sparkler-plugins/scorer-dd-svn/pom.xml
+++ b/sparkler-core/sparkler-plugins/scorer-dd-svn/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>sparkler-plugins</artifactId>
         <groupId>edu.usc.irds.sparkler.plugin</groupId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.2.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sparkler-core/sparkler-plugins/scorer-dd-svn/src/main/java/edu/usc/irds/sparkler/plugin/DdSvnScorer.java
+++ b/sparkler-core/sparkler-plugins/scorer-dd-svn/src/main/java/edu/usc/irds/sparkler/plugin/DdSvnScorer.java
@@ -17,7 +17,6 @@
 
 package edu.usc.irds.sparkler.plugin;
 
-
 import edu.usc.irds.sparkler.*;
 import edu.usc.irds.sparkler.plugin.ddsvn.ApacheHttpRestClient;
 import org.json.simple.JSONArray;
@@ -27,7 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -43,7 +41,7 @@ public class DdSvnScorer extends AbstractExtensionPoint implements Scorer {
 
     private ApacheHttpRestClient restClient= new ApacheHttpRestClient();
 
-    private LinkedHashMap<String, Object> pluginConfig;
+    private Map<String, Object> pluginConfig;
 
     private String uriClassifier;
 
@@ -76,7 +74,7 @@ public class DdSvnScorer extends AbstractExtensionPoint implements Scorer {
 
     @Override
     public Double score(String extractedText) throws Exception {
-        LinkedHashMap<String, Object> cfg = jobContext.getConfiguration().getPluginConfiguration(pluginId);
+        Map<String, Object> cfg = jobContext.getConfiguration().getPluginConfiguration(pluginId);
         this.uriClassifier = cfg.getOrDefault(SCORER_DD_SVN_URL, DEFAULT_SCORER_DD_SVN_URL).toString();
         this.fallbackScore = cfg.getOrDefault(FALLBACK_SCORE, DEFAULT_FALLBACK_SCORE).toString();
         this.scoreKey = cfg.getOrDefault(SCORE_KEY, DEFAULT_SCORE_KEY).toString();

--- a/sparkler-core/sparkler-plugins/template-plugin/pom.xml
+++ b/sparkler-core/sparkler-plugins/template-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>sparkler-plugins</artifactId>
         <groupId>edu.usc.irds.sparkler.plugin</groupId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.2.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sparkler-core/sparkler-plugins/url-injector/pom.xml
+++ b/sparkler-core/sparkler-plugins/url-injector/pom.xml
@@ -1,0 +1,52 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sparkler-plugins</artifactId>
+        <groupId>edu.usc.irds.sparkler.plugin</groupId>
+        <version>0.2.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>url-injector</artifactId>
+    <packaging>jar</packaging>
+
+    <name>url-injector</name>
+    <url>http://maven.apache.org</url>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <plugin.id>${project.artifactId}</plugin.id>
+        <plugin.version>${project.version}</plugin.version>
+        <plugin.provider>${project.groupId}</plugin.provider>
+        <plugin.class>edu.usc.irds.sparkler.plugin.UrlInjectorActivator</plugin.class>
+    </properties>
+    <dependencies>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin><!-- Config is same as defined in the parent POM -->
+                <artifactId>maven-assembly-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/sparkler-core/sparkler-plugins/url-injector/pom.xml
+++ b/sparkler-core/sparkler-plugins/url-injector/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>sparkler-plugins</artifactId>
         <groupId>edu.usc.irds.sparkler.plugin</groupId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.2.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sparkler-core/sparkler-plugins/url-injector/src/main/java/edu/usc/irds/sparkler/plugin/UrlInjector.java
+++ b/sparkler-core/sparkler-plugins/url-injector/src/main/java/edu/usc/irds/sparkler/plugin/UrlInjector.java
@@ -1,0 +1,26 @@
+package edu.usc.irds.sparkler.plugin;
+
+import edu.usc.irds.sparkler.AbstractExtensionPoint;
+import edu.usc.irds.sparkler.Config;
+
+import org.pf4j.Extension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Extension
+public class UrlInjector extends AbstractExtensionPoint implements Config {
+    
+    private static final Logger LOG = LoggerFactory.getLogger(UrlInjector.class);
+
+    @Override
+    public List<String> processConfig() {
+        System.out.println("hello");
+        LOG.debug("HELLO WORLD");
+        ArrayList<String> s = new ArrayList<>();
+
+        return s;
+    }
+}

--- a/sparkler-core/sparkler-plugins/url-injector/src/main/java/edu/usc/irds/sparkler/plugin/UrlInjector.java
+++ b/sparkler-core/sparkler-plugins/url-injector/src/main/java/edu/usc/irds/sparkler/plugin/UrlInjector.java
@@ -16,15 +16,15 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 
 @Extension
 public class UrlInjector extends AbstractExtensionPoint implements Config {
 
     private static final Logger LOG = LoggerFactory.getLogger(UrlInjector.class);
-    private LinkedHashMap<String, Object> pluginConfig;
+    private Map<String, Object> pluginConfig;
 
     @Override
     public Collection<UrlInjectorObj> processConfig(Collection<String> urls) {
@@ -63,7 +63,7 @@ public class UrlInjector extends AbstractExtensionPoint implements Config {
 
     private List<UrlInjectorObj> appendForm(Collection<String> urls, List<String> tokens) {
         List<UrlInjectorObj> fixedUrls = new ArrayList<>();
-        LinkedHashMap script = (LinkedHashMap) pluginConfig.get("form");
+        Map script = (Map) pluginConfig.get("form");
 
         JSONObject root = new JSONObject();
         JSONObject obj = new JSONObject(script);
@@ -143,7 +143,7 @@ public class UrlInjector extends AbstractExtensionPoint implements Config {
 
     private List<UrlInjectorObj> appendSelenium(Collection<String> urls, List<String> tokens) {
         List<UrlInjectorObj> fixedUrls = new ArrayList<>();
-        LinkedHashMap script = (LinkedHashMap) pluginConfig.get("selenium");
+        Map script = (Map) pluginConfig.get("selenium");
 
         JSONObject root = new JSONObject();
         JSONObject obj = new JSONObject(script);

--- a/sparkler-core/sparkler-plugins/url-injector/src/main/java/edu/usc/irds/sparkler/plugin/UrlInjectorActivator.java
+++ b/sparkler-core/sparkler-plugins/url-injector/src/main/java/edu/usc/irds/sparkler/plugin/UrlInjectorActivator.java
@@ -1,0 +1,11 @@
+package edu.usc.irds.sparkler.plugin;
+
+import org.pf4j.Plugin;
+import org.pf4j.PluginWrapper;
+
+public class UrlInjectorActivator extends Plugin {
+
+    public UrlInjectorActivator(PluginWrapper wrapper) {
+        super(wrapper);
+    }
+}

--- a/sparkler-core/sparkler-plugins/urlfilter-regex/pom.xml
+++ b/sparkler-core/sparkler-plugins/urlfilter-regex/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>sparkler-plugins</artifactId>
         <groupId>edu.usc.irds.sparkler.plugin</groupId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.2.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sparkler-core/sparkler-plugins/urlfilter-regex/src/main/java/edu/usc/irds/sparkler/plugin/RegexURLFilter.java
+++ b/sparkler-core/sparkler-plugins/urlfilter-regex/src/main/java/edu/usc/irds/sparkler/plugin/RegexURLFilter.java
@@ -17,7 +17,6 @@
 
 package edu.usc.irds.sparkler.plugin;
 
-
 import edu.usc.irds.sparkler.ConfigKey;
 import edu.usc.irds.sparkler.plugin.regex.RegexRule;
 import edu.usc.irds.sparkler.plugin.regex.RegexURLFilterBase;
@@ -26,7 +25,8 @@ import org.pf4j.Extension;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.util.LinkedHashMap;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 
@@ -44,7 +44,7 @@ public class RegexURLFilter extends RegexURLFilterBase {
      * Rules specified as a config property will override rules specified as a
      * config file.
      */
-    protected Reader getRulesReader(LinkedHashMap pluginConfig) throws IOException {
+    protected Reader getRulesReader(Map pluginConfig) throws IOException {
         String regexFile = pluginConfig.get(URLFILTER_REGEX_FILE).toString();
         return new InputStreamReader(jobContext.getClass().getClassLoader().getResource(regexFile).openStream());
     }

--- a/sparkler-core/sparkler-plugins/urlfilter-regex/src/main/java/edu/usc/irds/sparkler/plugin/regex/RegexURLFilterBase.java
+++ b/sparkler-core/sparkler-plugins/urlfilter-regex/src/main/java/edu/usc/irds/sparkler/plugin/regex/RegexURLFilterBase.java
@@ -33,8 +33,8 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -96,7 +96,7 @@ public abstract class RegexURLFilterBase extends AbstractExtensionPoint implemen
         super.init(context, pluginId);
         try {
             SparklerConfiguration config = jobContext.getConfiguration();
-            LinkedHashMap pluginConfig = config.getPluginConfiguration(pluginId);
+            Map pluginConfig = config.getPluginConfiguration(pluginId);
             Reader reader = getRulesReader(pluginConfig);
             this.rules = readRules(reader);
         } catch (IOException e) {
@@ -138,7 +138,7 @@ public abstract class RegexURLFilterBase extends AbstractExtensionPoint implemen
      *          is the current configuration.
      * @return the name of the resource containing the rules to use.
      */
-    protected abstract Reader getRulesReader(LinkedHashMap pluginConfig) throws IOException;
+    protected abstract Reader getRulesReader(Map pluginConfig) throws IOException;
 
 
     public boolean filter(String url, String parent) {

--- a/sparkler-core/sparkler-plugins/urlfilter-samehost/pom.xml
+++ b/sparkler-core/sparkler-plugins/urlfilter-samehost/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>sparkler-plugins</artifactId>
         <groupId>edu.usc.irds.sparkler.plugin</groupId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.2.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sparkler-core/sparkler-tests-base/pom.xml
+++ b/sparkler-core/sparkler-tests-base/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>sparkler-parent</artifactId>
     <groupId>edu.usc.irds.sparkler</groupId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.2.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/sparkler-core/sparkler-ui/pom.xml
+++ b/sparkler-core/sparkler-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>sparkler-parent</artifactId>
         <groupId>edu.usc.irds.sparkler</groupId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.2.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
This incoming PR will address the following requirements we had with Sparkler:

**Inject Plugins**
Plugins on the inject side to allow users to massage URLs being fed into Sparkler.
For example, we wanted to be able to submit 1 url but with a bunch of parameters and have Sparkler inject 1 url per parameter into Solr for crawling.

**PUT/POST Requests**
Sparkler will also be able to deal with PUT/POST and GET requests, if a user prepends a URL with POST|http://us.cnn.com for example, sparkler will POST the request, this can make life easier for doing searches etc on various sites that expect a POST.

**Config Overload**
You can now overload the config on the command line by passing in a json string with any additional or replacement keys. This allows you to deploy a sensible default config but then do per site overrides or similar in a server environment without having to rewrite config file each time for plugin changes etc.

**Additional fields**
There is also a new metadata field that plugins can make use of. In our case, having our injector plugin deal with a selenium script and pass it to our fetcher plugin. But rather than make it specifically for selenium we thought a metadata blob would be better so other processes could make use of it, for example in our next feature.

**URL Injector**
The URL injector plugin now allows 4 modes:

1 Replace:

Pass in a single url and replace ${token} with an item from a list.
For example:

URL: http://${token}.bbc.co.uk
Token list: "sport", "news"

The plugin will return 2 urls, https://news.bbc.co.uk and https://sport.bbc.co.uk for crawling.

2 Selenium:

Pass in a single url and a tokenised selenium script and have it replace the ${token} in the selenium script with the token list you pass in. Useful for selenium driven search interfaces in the fetcher-chrome plugin and others.

3 JSON:

Pass a single url and a tokenised json string and have it replace the ${token} in the string with a value and pass via the metadata field to the fetcher so that it can POST json to a URL.

4 FORM:

Submit a form field with all the bits and pieces filled in.

**Chrome Fetcher Fixes**
I've made changes to the chrome driver fetcher which now uses an transparent proxy to allow a more effective interface. Before, because of the way selenium works we couldn't fetch the response code, so we'd do anther plain HTTP request on the java side to get that. Now I've plugged in a proxy and we can sniff the response which saves grabbing the page twice and is more efficient.

**Fetcher Default Fixes**
When testing a site I found my headers weren't getting applied, it appears Fetcher Default is some weird half plugin half not plugin and the init() setup isn't called. I'll fix this.