### PR TITLE
[Docker] Update run script with relative paths and docker-compose file

### DIFF
--- a/sparkler-core/bin/sparkler.sh
+++ b/sparkler-core/bin/sparkler.sh
@@ -1,5 +1,23 @@
 #!/usr/bin/env bash
 
+# Attempt to resolve the sparkler jar using relative paths
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR="$DIR/.."
+
+JAR=`echo $DIR/sparkler-app-*-SNAPSHOT.jar`
+if [ -f "$JAR" ]
+ then
+    # run
+    # -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005
+    java -Xms1g -cp $DIR/conf:$JAR -Dpf4j.pluginsDir=$DIR/plugins edu.usc.irds.sparkler.Main $@
+    exit 0
+fi
+
+# Attempt to resolve the sparkler jar using absolute paths
+# We do this because in the elastic-search deployment we add sparkler.sh to /usr/bin
+# In that case the Sparkler jar cannot be resolved via relative paths.
+# The followig code block resolves the absolute location of this script on disk
+# We assume that it is located in sparkler-core/bin/
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
   DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
@@ -7,9 +25,9 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
   [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
-SPARKLER_CORE_DIR="$DIR/.."
+SPARKLER_BUILD_DIR="$DIR/../build"
 
-JAR=`echo $SPARKLER_CORE_DIR/build/sparkler-app-*-SNAPSHOT.jar`
+JAR=`echo $SPARKLER_BUILD_DIR/sparkler-app-*-SNAPSHOT.jar`
 if [ ! -f "$JAR" ]
  then
     echo "ERROR: Can't find Sparkler Jar at $JAR.
@@ -19,4 +37,4 @@ fi
 
 # run
 # -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005
-java -Xms1g -cp $DIR/conf:$JAR -Dpf4j.pluginsDir=$SPARKLER_CORE_DIR/build/plugins edu.usc.irds.sparkler.Main $@
+java -Xms1g -cp $DIR/conf:$JAR -Dpf4j.pluginsDir=$SPARKLER_BUILD_DIR/plugins edu.usc.irds.sparkler.Main $@

--- a/sparkler-core/sparkler-deployment/docker/elasticsearch/docker-compose.yml
+++ b/sparkler-core/sparkler-deployment/docker/elasticsearch/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - 4041:4041
     volumes:
       - type: bind
-        source: .
+        source: ../../../
         target: /data/sparkler-core
   elasticsearch:
     container_name: elasticsearch


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Update sparkler.sh to use relative paths and absolute paths to resolve sparkler jar directory
2. Update elasticsearch docker-compose.yml to specify bind volume using relative paths

'Closes #219 '.

### How was this patch tested?
For changes to sparkler.sh
1. ran `sparkler-core/sparkler-deployment/docker/elasticsearch/dockler.py --up`. Logged into sparkler-elastic container. Ran `sparkler` to verify sparkler can be started when symlinked to `/usr/bin`. @buggtb to confirm if this fix resolves issue where sparkler.sh and jar are moved to different locations on disk

For changes to docker-compose.yml
1. ran `docker inspect sparkler-elastic`. Verified the bind volume path corresponded to the `sparkler-core` directory
```
docker inspect sparkler-elastic
"Mounts": [
    {
        "Type": "bind",
        "Source": "/Users/handyal/source/sparkler/sparkler-core",
        "Destination": "/data/sparkler-core",
        "Mode": "",
        "RW": true,
        "Propagation": "rprivate"
    }
],
```
