### PR TITLE
SPARKLER-236 Exclude net.jpountz.lz4 lz4 from kafka-clients dependency in sparkler-app/pom.xml

### DIFF
--- a/sparkler-core/sparkler-app/pom.xml
+++ b/sparkler-core/sparkler-app/pom.xml
@@ -96,8 +96,13 @@
            <groupId>org.apache.kafka</groupId>
            <artifactId>kafka-clients</artifactId>
            <version>${kafka.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.jpountz.lz4</groupId>
+                    <artifactId>lz4</artifactId>
+                </exclusion>
+            </exclusions>
          </dependency>
-
 
         <dependency>
             <groupId>org.apache.solr</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR addresses the issue reported in https://github.com/USCDataScience/sparkler/issues/236

**Is this related to an already existing issue on sparkler?**  
https://github.com/USCDataScience/sparkler/issues/236

**Will it close an existing issue?**  
Closes https://github.com/USCDataScience/sparkler/issues/236


### How was this patch tested?
```
% cd sparkler-core && mvn clean install -DskipTests
% docker build -t sparkler-local -f sparkler-deployment/docker/Dockerfile .
% docker run -p 8983:8983 -p 4041:4040 -it --user sparkler -d 662c89b5cfb8
% docker exec -it --user sparkler 83ba4d5fc174418bcd8eeee78618c6fa45de2a79398000e5954f0600a45d14a1 /bin/bash
% /data/solr/bin/solr start -force
% /data/sparkler/bin/sparkler.sh inject -id 1 -su "https://www.lemonde.fr/"
% /data/sparkler/bin/sparkler.sh crawl -id 1 -tn 10 -i 2
```
... now the crawl executes and finishes without any issues.