### PR TITLE
Bump Ms to v0.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 *.jar
 *.war
 core/build/**
+build/**
 
 # sbt specific
 .cache

--- a/project/PluginDependencies.scala
+++ b/project/PluginDependencies.scala
@@ -29,7 +29,7 @@ object FetcherChrome {
   }
   lazy val browserup = "com.browserup" % "browserup-proxy-core" % "3.0.0-SNAPSHOT"
   lazy val seleniumscripter = "uk.co.spicule" % "seleniumscripter" % "1.7.9"
-  lazy val magnesium_script = "uk.co.spicule" % "magnesium-script" % "0.2.0"
+  lazy val magnesium_script = "uk.co.spicule" % "magnesium-script" % "0.4.0"
 }
 
 object FetcherHtmlUnit {


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Updated Fetcher Chrome to depend on Ms v0.4.0


<a href="https://gitpod.io/#https://github.com/USCDataScience/sparkler/pull/256"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

